### PR TITLE
ci: optimize workflows to reduce billable minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [master, dev]
   pull_request:
     branches: [master, dev]
 
@@ -13,23 +11,16 @@ concurrency:
 jobs:
   # ── Gate: PRs to master must bump version and update changelog ──
   release-checks:
+    if: github.base_ref == 'master'
     runs-on: ubuntu-latest
     steps:
-      - name: Skip — not a PR to master
-        if: ${{ !(github.event_name == 'pull_request' && github.base_ref == 'master') }}
-        run: echo "Not a PR to master — release checks not required."
-
       - uses: actions/checkout@v5
-        if: github.event_name == 'pull_request' && github.base_ref == 'master'
         with:
           fetch-depth: 0
 
       - name: Check package.json version was bumped
-        if: github.event_name == 'pull_request' && github.base_ref == 'master'
         run: |
-          # Get the version on master (base branch)
           MASTER_VERSION=$(git show origin/master:package.json | python3 -c "import sys,json; print(json.load(sys.stdin)['version'])")
-          # Get the version in this PR
           PR_VERSION=$(python3 -c "import json; print(json.load(open('package.json'))['version'])")
 
           echo "Master version: $MASTER_VERSION"
@@ -43,9 +34,7 @@ jobs:
           echo "Version bumped: $MASTER_VERSION → $PR_VERSION"
 
       - name: Check CHANGELOG.md was updated
-        if: github.event_name == 'pull_request' && github.base_ref == 'master'
         run: |
-          # Check if CHANGELOG.md has changes compared to master
           if git diff --quiet origin/master -- CHANGELOG.md; then
             echo "::error::CHANGELOG.md has not been updated. PRs to master must include changelog entries."
             exit 1
@@ -53,7 +42,8 @@ jobs:
 
           echo "CHANGELOG.md has been updated."
 
-  lint:
+  # ── Quality: lint, format, type-check in a single job ──
+  quality:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -63,22 +53,14 @@ jobs:
       - run: npm install
       - run: npm run lint
       - run: npm run format:check
-
-  type-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 22
-      - run: npm install
       - run: npm run type-check
 
+  # ── Tests: full matrix on PRs to master, slim on PRs to dev ──
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [20, 22]
+        os: ${{ github.base_ref == 'master' && fromJSON('["ubuntu-latest","macos-latest","windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
+        node: ${{ github.base_ref == 'master' && fromJSON('[20, 22]') || fromJSON('[22]') }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
@@ -88,8 +70,9 @@ jobs:
       - run: npm install
       - run: npm test
 
+  # ── Build: verify the package compiles ──
   build:
-    needs: [type-check]
+    needs: [quality]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,26 +99,9 @@ jobs:
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
           fi
 
-  # ── Validate: full CI checks before publishing ──
-  validate:
-    needs: [preflight]
-    if: needs.preflight.outputs.should_publish == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 22
-      - run: npm install
-      - run: npm run lint
-      - run: npm run format:check
-      - run: npm run type-check
-      - run: npm test
-      - run: npm run build
-
   # ── Publish to npm with OIDC trusted publishing ──
   publish:
-    needs: [preflight, validate]
+    needs: [preflight]
     if: needs.preflight.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     environment: publishing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-04-03
+
 ### Changed
 
 - CI workflow triggers on pull_request only (removed redundant push triggers)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- CI workflow triggers on pull_request only (removed redundant push triggers)
+- Test matrix: full 3 OS x 2 Node for PRs to master, Ubuntu + Node 22 only for PRs to dev
+- Merged lint, format, and type-check into a single `quality` job
+- Removed redundant `validate` job from publish workflow (CI already gates the PR)
+
 ### Fixed
 
 - Prettier formatting applied to 25 files (tests, docs, fixtures)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solanticai/vguard",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "AI coding guardrails framework. Runtime-enforced quality controls for Claude Code, Cursor, Codex, and more.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- CI triggers on `pull_request` only — removed redundant `push` triggers that doubled every run
- Test matrix: full 3 OS x 2 Node for PRs to master, Ubuntu + Node 22 only for PRs to dev (~87% savings on routine PRs)
- Merged `lint`, `format:check`, and `type-check` into a single `quality` job (saves one checkout + install cycle)
- Removed redundant `validate` job from publish workflow — CI already gates the PR

## Test plan

- [ ] PR to `dev` triggers CI with slim test matrix (1 job)
- [ ] PR to `master` triggers CI with full test matrix (6 jobs) + release-checks
- [ ] Push to `dev`/`master` does **not** trigger CI workflow
- [ ] Merge to `master` triggers only the publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)