### PR TITLE
fix(cloud): repair default URL and credential persistence for sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Cloud sync default URL now points to `https://vguard.dev` instead of the
+  non-resolving `https://api.vguard.dev` / `https://app.vguard.dev` subdomains.
+  Affected the streamer (`/api/v1/ingest`), CloudClient base URL, and the
+  `cloud login` / `cloud connect` browser URLs. Users can still override via
+  `VGUARD_CLOUD_URL`.
+- `vguard cloud connect --key <vc_...> --project-id <id>` now always writes
+  the API key + project ID to `~/.vguard/credentials.json`, even when the
+  user has not previously run `vguard cloud login`. Previously the
+  credentials file was only updated if it already existed, which meant
+  Claude Code hooks had no way to read the API key and silently skipped
+  real-time cloud streaming.
 - Prettier formatting applied to 6 new rule and test files
 
 ## [1.3.0] - 2026-04-04

--- a/src/cli/commands/cloud-connect.ts
+++ b/src/cli/commands/cloud-connect.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { hasValidCredentials, readCredentials, writeCredentials } from '../../cloud/credentials.js';
 import { CloudClient } from '../../cloud/client.js';
 
-const CLOUD_URL = process.env.VGUARD_CLOUD_URL ?? 'https://app.vguard.dev';
+const CLOUD_URL = process.env.VGUARD_CLOUD_URL ?? 'https://vguard.dev';
 
 /**
  * `vguard cloud connect`
@@ -55,12 +55,12 @@ export async function cloudConnectCommand(
     }
   }
 
-  // Save API key and project ID to credentials
+  // Save API key and project ID to credentials.
+  // Always persist so Claude Code hooks can read them, even when the user
+  // connects via --key/--project-id without having run `cloud login` first.
   const creds = readCredentials();
-  if (creds) {
-    writeCredentials({ ...creds, apiKey, projectId });
-    console.log('  Saved API key to credentials.');
-  }
+  writeCredentials({ ...(creds ?? {}), apiKey, projectId });
+  console.log('  Saved API key to credentials.');
 
   // Auto-update vguard.config.ts
   if (updateConfigFile(projectRoot, projectId)) {

--- a/src/cli/commands/cloud-login.ts
+++ b/src/cli/commands/cloud-login.ts
@@ -3,7 +3,7 @@ import crypto from 'node:crypto';
 import { execFile } from 'node:child_process';
 import { readCredentials, writeCredentials, getCredentialsPath } from '../../cloud/credentials.js';
 
-const DEFAULT_CLOUD_URL = process.env.VGUARD_CLOUD_URL ?? 'https://app.vguard.dev';
+const DEFAULT_CLOUD_URL = process.env.VGUARD_CLOUD_URL ?? 'https://vguard.dev';
 const DEFAULT_SUPABASE_URL =
   process.env.VGUARD_SUPABASE_URL ?? 'https://mpisrdadthdhpvgimtzv.supabase.co';
 const DEFAULT_OAUTH_CLIENT_ID =

--- a/src/cloud/client.ts
+++ b/src/cloud/client.ts
@@ -1,6 +1,6 @@
 import { readCredentials, getValidCredentials } from './credentials.js';
 
-const DEFAULT_API_URL = process.env.VGUARD_CLOUD_URL ?? 'https://api.vguard.dev';
+const DEFAULT_API_URL = process.env.VGUARD_CLOUD_URL ?? 'https://vguard.dev';
 
 export interface CloudClientOptions {
   apiUrl?: string;
@@ -79,7 +79,7 @@ export class CloudClient {
 
   private async authenticatedRequest(path: string, init?: RequestInit): Promise<unknown> {
     const credentials = await getValidCredentials();
-    if (!credentials) {
+    if (!credentials?.accessToken) {
       throw new Error('Not logged in or session expired. Run `npx vguard cloud login` first.');
     }
 

--- a/src/cloud/credentials.ts
+++ b/src/cloud/credentials.ts
@@ -6,8 +6,9 @@ const CREDENTIALS_DIR = join(homedir(), '.vguard');
 const CREDENTIALS_FILE = join(CREDENTIALS_DIR, 'credentials.json');
 
 export interface CloudCredentials {
-  /** Supabase access token (JWT) */
-  accessToken: string;
+  /** Supabase access token (JWT) — set by `cloud login`, absent when user
+   *  connects via `cloud connect --key` with an existing API key. */
+  accessToken?: string;
   /** Supabase refresh token — used to get new access tokens when expired */
   refreshToken?: string;
   /** Token expiry timestamp (ISO 8601) */

--- a/src/cloud/streamer.ts
+++ b/src/cloud/streamer.ts
@@ -161,7 +161,7 @@ export async function maybeFlushToCloud(
     try {
       const body = batch.map((r) => JSON.stringify(r)).join('\n');
       const url =
-        (process.env.VGUARD_CLOUD_URL ?? 'https://api.vguard.dev').replace(/\/$/, '') +
+        (process.env.VGUARD_CLOUD_URL ?? 'https://vguard.dev').replace(/\/$/, '') +
         '/api/v1/ingest';
 
       const res = await fetch(url, {

--- a/tests/cli/cloud-commands.test.ts
+++ b/tests/cli/cloud-commands.test.ts
@@ -29,10 +29,10 @@ describe('cloud credential operations', () => {
 
   describe('login credential storage', () => {
     it('stores credentials on success', () => {
-      writeCredentials({ apiKey: 'vguard_test_key_123', endpoint: 'https://api.vguard.dev' });
+      writeCredentials({ apiKey: 'vguard_test_key_123', endpoint: 'https://vguard.dev' });
       expect(writeCredentials).toHaveBeenCalledWith({
         apiKey: 'vguard_test_key_123',
-        endpoint: 'https://api.vguard.dev',
+        endpoint: 'https://vguard.dev',
       });
     });
   });
@@ -48,7 +48,7 @@ describe('cloud credential operations', () => {
     it('detects valid credentials', () => {
       vi.mocked(readCredentials).mockReturnValue({
         apiKey: 'vguard_test_key_123',
-        endpoint: 'https://api.vguard.dev',
+        endpoint: 'https://vguard.dev',
       });
       const creds = readCredentials();
       expect(creds).toBeDefined();


### PR DESCRIPTION
## Summary

Two bugs in the cloud streaming path were preventing every consumer's Claude Code hooks from uploading rule-hit telemetry. Confirmed end-to-end by manual validation (85 buffered rule hits from \`lumioh-operations\` now land in VGuard Cloud after these fixes).

## Bugs fixed

### 1. Wrong default cloud URLs
- Streamer, CloudClient, and CLI browser commands all defaulted to \`api.vguard.dev\` / \`app.vguard.dev\`, neither of which resolves (DNS-only, no route).
- The actual cloud deployment serves \`/api/v1/ingest\` from \`https://vguard.dev\` (confirmed via \`curl\` — returns \`cache-tag: vibe-guard-cloud\`).
- **Fix:** all four defaults now point to \`https://vguard.dev\`. Users can still override via \`VGUARD_CLOUD_URL\`.

### 2. \`cloud connect --key\` never persisted credentials file
- \`vguard cloud connect --key <vc_...> --project-id <id>\` only wrote \`apiKey\` + \`projectId\` to \`~/.vguard/credentials.json\` **if the file already existed** (i.e., after a prior \`cloud login\`).
- If a user connected via \`--key\` alone, the key landed only in \`.env.local\`, which Claude Code hook subprocesses cannot read (it's a Next.js-only convention).
- Result: hooks ran and logged locally but \`triggerRealTimeStream()\` silently gave up when it couldn't find an API key, leaving projects permanently "Never synced".
- **Fix:** command now always persists \`apiKey\` + \`projectId\` to the credentials file.

### Type change
\`CloudCredentials.accessToken\` is now optional, reflecting the fact that users connecting via \`--key\` never obtain an OAuth access token. The \`authenticatedRequest\` path guards on \`accessToken\` before emitting a Bearer header.

## Test plan
- [x] \`npm run type-check\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm test\` — 678/678 passing
- [x] \`npm run build\` — ESM + CJS success
- [x] Verified end-to-end: 85 buffered rule hits synced from lumioh-operations to vguard.dev via \`npx vguard sync\` with the fix applied