### PR TITLE
feat(cloud): push resolved config snapshot + CLI version to Cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Config-snapshot sync: the hook runner now pushes the resolved project
+  configuration + CLI version to VGuard Cloud whenever the resolved
+  config hash changes or 24h have passed since the last push. This
+  populates `projects.config_snapshot` and `projects.vguard_version`
+  in the cloud database, which in turn lights up the dashboard's
+  Active Presets, Quick Stats, Project Rules, Config Resolution
+  Pipeline, and version-badge widgets. Previously those widgets were
+  always empty because nothing in the CLI ever wrote to those columns.
+  Override the endpoint host via `VGUARD_FUNCTIONS_URL` for self-hosted
+  Supabase projects.
+- `vguard sync` command also pushes the config snapshot after a
+  successful rule-hits sync, as a manual fallback when hooks are
+  disabled or haven't run recently.
+
 ### Changed
 
 - `.husky/pre-commit` now skips the CHANGELOG.md / version-bump checks

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -1,5 +1,6 @@
 import { syncToCloud } from '../../cloud/sync.js';
 import { readCredentials } from '../../cloud/credentials.js';
+import { maybePushConfigSnapshot } from '../../cloud/config-pusher.js';
 
 /**
  * `vguard sync`
@@ -38,9 +39,20 @@ export async function syncCommand(
 
   if (options.dryRun) {
     console.log(`  Would sync ${result.skipped} records.\n`);
-  } else if (result.synced > 0) {
-    console.log(`  Synced ${result.synced} records to Cloud.\n`);
+    return;
+  }
+
+  if (result.synced > 0) {
+    console.log(`  Synced ${result.synced} records to Cloud.`);
   } else {
-    console.log('  No new records to sync.\n');
+    console.log('  No new records to sync.');
+  }
+
+  // Also push the resolved config snapshot (no-op if unchanged + recent)
+  const configPush = await maybePushConfigSnapshot(projectRoot, apiKey);
+  if (configPush.pushed) {
+    console.log('  Pushed project config snapshot to Cloud.\n');
+  } else {
+    console.log('');
   }
 }

--- a/src/cloud/client.ts
+++ b/src/cloud/client.ts
@@ -66,9 +66,7 @@ export class CloudClient {
       });
       if (!res.ok) {
         const errBody = (await res.json().catch(() => ({}))) as Record<string, unknown>;
-        throw new Error(
-          `Config push failed (${res.status}): ${errBody.message ?? res.statusText}`,
-        );
+        throw new Error(`Config push failed (${res.status}): ${errBody.message ?? res.statusText}`);
       }
       return (await res.json()) as { updated: boolean; projectId: string };
     } finally {

--- a/src/cloud/client.ts
+++ b/src/cloud/client.ts
@@ -1,6 +1,14 @@
 import { readCredentials, getValidCredentials } from './credentials.js';
+import type { ProjectConfigPushPayload } from '../types.js';
 
 const DEFAULT_API_URL = process.env.VGUARD_CLOUD_URL ?? 'https://vguard.dev';
+/**
+ * Base URL for Supabase Edge Functions. These live on a different host
+ * from the main Next.js app. Override via VGUARD_FUNCTIONS_URL for
+ * self-hosted Supabase instances or preview environments.
+ */
+const DEFAULT_FUNCTIONS_URL =
+  process.env.VGUARD_FUNCTIONS_URL ?? 'https://mpisrdadthdhpvgimtzv.supabase.co';
 
 export interface CloudClientOptions {
   apiUrl?: string;
@@ -27,6 +35,45 @@ export class CloudClient {
     const url = options.apiUrl ?? creds?.apiUrl ?? DEFAULT_API_URL;
     this.apiUrl = url.replace(/\/$/, '');
     this.apiKey = options.apiKey;
+  }
+
+  /**
+   * POST a resolved config snapshot + vguard version to the
+   * ingest-config Edge Function so the dashboard can populate its
+   * presets / rules / version widgets for this project. Uses project
+   * API key authentication (same X-API-Key as `ingest()`).
+   *
+   * The endpoint lives on the Supabase Edge Function host, not on the
+   * main API host — hence the separate base URL.
+   */
+  async pushConfigSnapshot(
+    apiKey: string,
+    payload: ProjectConfigPushPayload,
+    timeoutMs = 5_000,
+  ): Promise<{ updated: boolean; projectId: string }> {
+    const url = DEFAULT_FUNCTIONS_URL.replace(/\/$/, '') + '/functions/v1/ingest-config';
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-API-Key': apiKey,
+        },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        const errBody = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+        throw new Error(
+          `Config push failed (${res.status}): ${errBody.message ?? res.statusText}`,
+        );
+      }
+      return (await res.json()) as { updated: boolean; projectId: string };
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   /**

--- a/src/cloud/config-pusher.ts
+++ b/src/cloud/config-pusher.ts
@@ -1,0 +1,188 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { join, dirname } from 'node:path';
+import type { ProjectConfigPushPayload } from '../types.js';
+import { CloudClient } from './client.js';
+
+/**
+ * Throttled pusher for project config snapshots.
+ *
+ * Responsibilities:
+ *   1. Load the resolved config snapshot and vguard version from disk
+ *   2. Compute a stable hash of the snapshot
+ *   3. Skip the push if the hash is unchanged AND the last push was
+ *      less than 24h ago
+ *   4. Otherwise POST to /functions/v1/ingest-config and persist the
+ *      new (hash, timestamp) pair
+ *
+ * Fail-open: every error is swallowed. Config push is telemetry-
+ * adjacent and must never break a developer's workflow.
+ */
+
+const STATE_FILE = '.vguard/data/config-sync-state.json';
+const RESOLVED_CONFIG_FILE = '.vguard/cache/resolved-config.json';
+const PACKAGE_JSON_FILE = 'package.json';
+const VGUARD_PACKAGE_JSON_PATH = 'node_modules/@solanticai/vguard/package.json';
+const THROTTLE_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+interface ConfigSyncState {
+  lastPushedHash: string;
+  lastPushedAt: string;
+}
+
+interface ResolvedConfigFile {
+  presets?: string[];
+  agents?: string[];
+  profile?: string;
+  rules?: Record<
+    string,
+    { enabled?: boolean; severity?: 'pass' | 'warn' | 'block'; options?: unknown }
+  >;
+  resolvedAt?: string;
+  language?: string;
+  framework?: string;
+}
+
+/**
+ * Main entry point. Reads disk state, decides whether to push, performs
+ * the push, and updates state on success. Returns an object describing
+ * what happened (useful for tests and the manual `vguard sync` command).
+ */
+export async function maybePushConfigSnapshot(
+  projectRoot: string,
+  apiKey: string,
+): Promise<{ pushed: boolean; reason: string }> {
+  try {
+    const resolved = readResolvedConfig(projectRoot);
+    if (!resolved) {
+      return { pushed: false, reason: 'no resolved config on disk' };
+    }
+
+    const vguardVersion = readVguardVersion(projectRoot);
+    if (!vguardVersion) {
+      return { pushed: false, reason: 'vguard version unknown' };
+    }
+
+    const payload = buildPayload(resolved, vguardVersion);
+    const hash = hashPayload(payload);
+    const state = readState(projectRoot);
+
+    if (
+      state &&
+      state.lastPushedHash === hash &&
+      Date.now() - new Date(state.lastPushedAt).getTime() < THROTTLE_MS
+    ) {
+      return { pushed: false, reason: 'unchanged + within 24h window' };
+    }
+
+    const client = new CloudClient();
+    await client.pushConfigSnapshot(apiKey, payload);
+
+    writeState(projectRoot, {
+      lastPushedHash: hash,
+      lastPushedAt: new Date().toISOString(),
+    });
+
+    return { pushed: true, reason: 'ok' };
+  } catch (err) {
+    return { pushed: false, reason: err instanceof Error ? err.message : 'error' };
+  }
+}
+
+/**
+ * Build the wire payload from the resolved config on disk. Exported so
+ * tests can exercise it without touching the filesystem.
+ */
+export function buildPayload(
+  resolved: ResolvedConfigFile,
+  vguardVersion: string,
+): ProjectConfigPushPayload {
+  const rules: ProjectConfigPushPayload['configSnapshot']['rules'] = {};
+  for (const [ruleId, config] of Object.entries(resolved.rules ?? {})) {
+    rules[ruleId] = {
+      enabled: config.enabled !== false,
+      severity: config.severity ?? 'warn',
+      options: config.options,
+    };
+  }
+
+  const payload: ProjectConfigPushPayload = {
+    vguardVersion,
+    configSnapshot: {
+      presets: resolved.presets ?? [],
+      rules,
+      agents: resolved.agents ?? [],
+      profile: resolved.profile,
+      resolvedAt: resolved.resolvedAt ?? new Date().toISOString(),
+    },
+  };
+  if (resolved.language) payload.language = resolved.language;
+  if (resolved.framework) payload.framework = resolved.framework;
+  return payload;
+}
+
+/**
+ * Compute a stable content hash of the outgoing payload. Only the
+ * configSnapshot + version contribute — language/framework don't
+ * change the dashboard render and would cause extra pushes without
+ * providing new data.
+ */
+export function hashPayload(payload: ProjectConfigPushPayload): string {
+  const stable = JSON.stringify({
+    v: payload.vguardVersion,
+    c: payload.configSnapshot,
+  });
+  return createHash('sha256').update(stable).digest('hex');
+}
+
+function readResolvedConfig(projectRoot: string): ResolvedConfigFile | null {
+  try {
+    const path = join(projectRoot, RESOLVED_CONFIG_FILE);
+    if (!existsSync(path)) return null;
+    return JSON.parse(readFileSync(path, 'utf-8')) as ResolvedConfigFile;
+  } catch {
+    return null;
+  }
+}
+
+function readVguardVersion(projectRoot: string): string | null {
+  // Prefer the installed package's own version; fall back to the
+  // consumer project's package.json if somehow we're running outside
+  // node_modules (e.g. during development).
+  for (const candidate of [VGUARD_PACKAGE_JSON_PATH, PACKAGE_JSON_FILE]) {
+    try {
+      const path = join(projectRoot, candidate);
+      if (!existsSync(path)) continue;
+      const pkg = JSON.parse(readFileSync(path, 'utf-8')) as { version?: string };
+      if (typeof pkg.version === 'string' && pkg.version.length > 0) {
+        return pkg.version;
+      }
+    } catch {
+      // keep trying
+    }
+  }
+  return null;
+}
+
+export function readState(projectRoot: string): ConfigSyncState | null {
+  try {
+    const path = join(projectRoot, STATE_FILE);
+    if (!existsSync(path)) return null;
+    return JSON.parse(readFileSync(path, 'utf-8')) as ConfigSyncState;
+  } catch {
+    return null;
+  }
+}
+
+export function writeState(projectRoot: string, state: ConfigSyncState): void {
+  const path = join(projectRoot, STATE_FILE);
+  const tmp = path + '.tmp';
+  const dir = dirname(path);
+  try {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    writeFileSync(tmp, JSON.stringify(state, null, 2), 'utf-8');
+    renameSync(tmp, path);
+  } catch {
+    // non-critical
+  }
+}

--- a/src/engine/hook-entry.ts
+++ b/src/engine/hook-entry.ts
@@ -86,6 +86,7 @@ export async function executeHook(event: HookEvent): Promise<void> {
     // 7. Real-time streaming to cloud (every hook event if autoSync enabled)
     if (config.cloud?.autoSync === true) {
       triggerRealTimeStream(process.cwd(), config.cloud);
+      triggerConfigPush(process.cwd());
     }
 
     // 7b. Full flush on Stop events (catch any remaining buffered records)
@@ -133,6 +134,30 @@ function triggerRealTimeStream(projectRoot: string, cloudConfig: NonNullable<Clo
     })
     .catch(() => {
       // Fail open — streaming errors should never impact the developer
+    });
+}
+
+/**
+ * Push the resolved config snapshot to Cloud if it has changed since
+ * the last push (or if 24h have passed). Non-blocking, fire-and-forget
+ * — errors are silently ignored. The pusher has its own internal
+ * throttle + state file, so it is safe to call on every hook event.
+ */
+function triggerConfigPush(projectRoot: string): void {
+  void import('../cloud/config-pusher.js')
+    .then(({ maybePushConfigSnapshot }) => {
+      const envKey = process.env.VGUARD_API_KEY;
+      if (envKey) {
+        return maybePushConfigSnapshot(projectRoot, envKey);
+      }
+      return import('../cloud/credentials.js').then(({ readCredentials }) => {
+        const key = readCredentials()?.apiKey;
+        if (!key) return;
+        return maybePushConfigSnapshot(projectRoot, key);
+      });
+    })
+    .catch(() => {
+      // Fail open — config push errors should never impact the developer
     });
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -217,7 +217,10 @@ export interface ProjectConfigPushPayload {
   /** Resolved project configuration, serializable to JSON */
   configSnapshot: {
     presets: string[];
-    rules: Record<string, { enabled: boolean; severity: 'pass' | 'warn' | 'block'; options?: unknown }>;
+    rules: Record<
+      string,
+      { enabled: boolean; severity: 'pass' | 'warn' | 'block'; options?: unknown }
+    >;
     agents: string[];
     profile?: string;
     resolvedAt: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -204,6 +204,30 @@ export interface ResolvedConfig {
   cloud?: CloudConfig;
 }
 
+// ─── Cloud Config-Snapshot Push ─────────────────────────────────────────────
+
+/**
+ * Payload sent to POST /functions/v1/ingest-config.
+ * Populates projects.config_snapshot + projects.vguard_version so the
+ * dashboard can render preset/rules/config widgets for this project.
+ */
+export interface ProjectConfigPushPayload {
+  /** Semver of the @solanticai/vguard package running on the consumer */
+  vguardVersion: string;
+  /** Resolved project configuration, serializable to JSON */
+  configSnapshot: {
+    presets: string[];
+    rules: Record<string, { enabled: boolean; severity: 'pass' | 'warn' | 'block'; options?: unknown }>;
+    agents: string[];
+    profile?: string;
+    resolvedAt: string;
+  };
+  /** Primary language of the consumer codebase (e.g. "typescript") */
+  language?: string;
+  /** Primary framework (e.g. "nextjs-15") */
+  framework?: string;
+}
+
 // ─── Preset ─────────────────────────────────────────────────────────────────
 
 /** A preset bundles rule configurations for a tech stack */

--- a/tests/cloud/config-pusher.test.ts
+++ b/tests/cloud/config-pusher.test.ts
@@ -42,10 +42,7 @@ describe('config-pusher payload building', () => {
   });
 
   it('includes language + framework only when present', () => {
-    const withBoth = buildPayload(
-      { language: 'typescript', framework: 'nextjs-15' },
-      '1.4.0',
-    );
+    const withBoth = buildPayload({ language: 'typescript', framework: 'nextjs-15' }, '1.4.0');
     expect(withBoth.language).toBe('typescript');
     expect(withBoth.framework).toBe('nextjs-15');
 

--- a/tests/cloud/config-pusher.test.ts
+++ b/tests/cloud/config-pusher.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import { buildPayload, hashPayload } from '../../src/cloud/config-pusher.js';
+
+describe('config-pusher payload building', () => {
+  it('builds a minimal payload', () => {
+    const payload = buildPayload(
+      {
+        presets: ['nextjs-15'],
+        agents: ['claude-code'],
+        rules: {
+          'security/branch-protection': { enabled: true, severity: 'block' },
+        },
+        resolvedAt: '2026-04-05T00:00:00.000Z',
+      },
+      '1.4.0',
+    );
+
+    expect(payload.vguardVersion).toBe('1.4.0');
+    expect(payload.configSnapshot.presets).toEqual(['nextjs-15']);
+    expect(payload.configSnapshot.agents).toEqual(['claude-code']);
+    expect(payload.configSnapshot.rules['security/branch-protection']).toEqual({
+      enabled: true,
+      severity: 'block',
+      options: undefined,
+    });
+    expect(payload.configSnapshot.resolvedAt).toBe('2026-04-05T00:00:00.000Z');
+  });
+
+  it('defaults missing severity to warn and treats undefined enabled as true', () => {
+    const payload = buildPayload(
+      {
+        rules: {
+          'x/foo': {},
+          'x/bar': { enabled: false },
+        },
+      },
+      '1.4.0',
+    );
+    expect(payload.configSnapshot.rules['x/foo'].severity).toBe('warn');
+    expect(payload.configSnapshot.rules['x/foo'].enabled).toBe(true);
+    expect(payload.configSnapshot.rules['x/bar'].enabled).toBe(false);
+  });
+
+  it('includes language + framework only when present', () => {
+    const withBoth = buildPayload(
+      { language: 'typescript', framework: 'nextjs-15' },
+      '1.4.0',
+    );
+    expect(withBoth.language).toBe('typescript');
+    expect(withBoth.framework).toBe('nextjs-15');
+
+    const withoutAny = buildPayload({}, '1.4.0');
+    expect(withoutAny.language).toBeUndefined();
+    expect(withoutAny.framework).toBeUndefined();
+  });
+
+  it('preserves resolvedAt from the resolved file', () => {
+    const payload = buildPayload({ resolvedAt: '2020-01-01T00:00:00.000Z' }, '1.4.0');
+    expect(payload.configSnapshot.resolvedAt).toBe('2020-01-01T00:00:00.000Z');
+  });
+
+  it('falls back to now() for resolvedAt when missing', () => {
+    const before = Date.now();
+    const payload = buildPayload({}, '1.4.0');
+    const after = Date.now();
+    const parsed = new Date(payload.configSnapshot.resolvedAt).getTime();
+    expect(parsed).toBeGreaterThanOrEqual(before);
+    expect(parsed).toBeLessThanOrEqual(after);
+  });
+});
+
+describe('config-pusher hash stability', () => {
+  const basePayload = buildPayload(
+    {
+      presets: ['a', 'b'],
+      agents: ['claude-code'],
+      rules: { 'x/foo': { enabled: true, severity: 'warn' } },
+      resolvedAt: '2026-04-05T00:00:00.000Z',
+    },
+    '1.4.0',
+  );
+
+  it('returns the same hash for identical payloads', () => {
+    const clone = buildPayload(
+      {
+        presets: ['a', 'b'],
+        agents: ['claude-code'],
+        rules: { 'x/foo': { enabled: true, severity: 'warn' } },
+        resolvedAt: '2026-04-05T00:00:00.000Z',
+      },
+      '1.4.0',
+    );
+    expect(hashPayload(clone)).toBe(hashPayload(basePayload));
+  });
+
+  it('changes hash when vguard version changes', () => {
+    const bumped = buildPayload(
+      {
+        presets: ['a', 'b'],
+        agents: ['claude-code'],
+        rules: { 'x/foo': { enabled: true, severity: 'warn' } },
+        resolvedAt: '2026-04-05T00:00:00.000Z',
+      },
+      '1.4.1',
+    );
+    expect(hashPayload(bumped)).not.toBe(hashPayload(basePayload));
+  });
+
+  it('changes hash when presets change', () => {
+    const modified = buildPayload(
+      {
+        presets: ['a', 'b', 'c'],
+        agents: ['claude-code'],
+        rules: { 'x/foo': { enabled: true, severity: 'warn' } },
+        resolvedAt: '2026-04-05T00:00:00.000Z',
+      },
+      '1.4.0',
+    );
+    expect(hashPayload(modified)).not.toBe(hashPayload(basePayload));
+  });
+
+  it('changes hash when rule severity changes', () => {
+    const modified = buildPayload(
+      {
+        presets: ['a', 'b'],
+        agents: ['claude-code'],
+        rules: { 'x/foo': { enabled: true, severity: 'block' } },
+        resolvedAt: '2026-04-05T00:00:00.000Z',
+      },
+      '1.4.0',
+    );
+    expect(hashPayload(modified)).not.toBe(hashPayload(basePayload));
+  });
+
+  it('ignores language/framework for hashing (they do not affect the snapshot)', () => {
+    const withLang = buildPayload(
+      {
+        presets: ['a', 'b'],
+        agents: ['claude-code'],
+        rules: { 'x/foo': { enabled: true, severity: 'warn' } },
+        resolvedAt: '2026-04-05T00:00:00.000Z',
+        language: 'typescript',
+        framework: 'nextjs-15',
+      },
+      '1.4.0',
+    );
+    expect(hashPayload(withLang)).toBe(hashPayload(basePayload));
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 of the 1.4.0 migration, CLI side. Adds a config-snapshot push path so the dashboard widgets that read from \`projects.config_snapshot\` and \`projects.vguard_version\` actually have data.

Companion server-side Edge Function ships in [vibe-guard-cloud PR #4](https://github.com/solanticai/vibe-guard-cloud/pull/4) (merge that one first so the endpoint is live when this code starts calling it).

## Why this PR exists

Those two columns have existed in the cloud schema since day one but have never had a writer. As a result, every consumer project's dashboard has shown empty Active Presets cards, empty rules tables, empty Config Resolution Pipeline, and a blank version badge, even when rule-hits ingestion was working perfectly. This closes that loop.

## New

- \`src/cloud/config-pusher.ts\` — throttled pusher: pushes when either the sha256 of the resolved config has changed OR 24h have passed since the last push. Persists state to \`.vguard/data/config-sync-state.json\`. Fail-open on every error.
- \`src/cloud/client.ts\` — \`pushConfigSnapshot()\` method using the existing \`vc_...\` X-API-Key, targeting the new ingest-config Edge Function on the Supabase host (configurable via \`VGUARD_FUNCTIONS_URL\`).
- \`src/engine/hook-entry.ts\` — \`triggerConfigPush()\` fires alongside \`triggerRealTimeStream()\` whenever \`cloud.autoSync\` is true. The pusher's internal throttle means this is safe to call on every hook event.
- \`src/cli/commands/sync.ts\` — \`vguard sync\` also pushes the snapshot after the rule-hits sync, for users running manual syncs or who don't have autoSync enabled.
- \`src/types.ts\` — \`ProjectConfigPushPayload\` wire shape.
- 10 new tests in \`tests/cloud/config-pusher.test.ts\` covering \`buildPayload()\` defaults + \`hashPayload()\` stability.

## Throttling logic

\`\`\`
1. Read .vguard/cache/resolved-config.json
2. Read vguard version from node_modules/@solanticai/vguard/package.json
   (fallback: consumer project's package.json)
3. Compute sha256(vguardVersion + configSnapshot)
4. If stored hash matches AND last push < 24h ago → skip
5. Otherwise POST to /functions/v1/ingest-config, persist new (hash, timestamp)
\`\`\`

language and framework are sent on every push but do not contribute to the hash — they shouldn't force extra pushes.

## Test plan

- [x] \`npm run type-check\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm test\` — 688 passing (10 new)
- [x] \`npm run build\` — ESM + CJS success
- [x] Smoke test against production: valid push returns \`{updated:true, projectId:...}\`, \`config_snapshot\` + \`vguard_version\` persist in \`projects\` row (verified via direct DB query, not in this CI)

Part of the [1.4.0 release plan](https://github.com/solanticai/vibe-guard/pull/8). Once this and vibe-guard-cloud#4 merge, run \`/release\` from dev to cut 1.4.0.