### PR TITLE
fix(cloud): ship cloud config in snapshot; force-enable on connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Config-snapshot push now includes the `cloud` block (`enabled`,
+  `autoSync`, `projectId`, `excludePaths`) so the dashboard's resolved-
+  config summary can correctly render "Cloud sync: enabled" for
+  projects that have streaming turned on. In 1.4.0 the cloud fields
+  were silently omitted from the payload, which made every project
+  show as "Cloud sync: disabled" even when real-time streaming was
+  working.
+- `vguard cloud connect` now upserts `enabled: true` and `autoSync:
+true` into an existing `cloud: { … }` block in vguard.config.ts,
+  not just `projectId`. Before this fix, a user who had previously
+  set `enabled: false` or `autoSync: false` and then ran
+  `cloud connect` would get their project ID updated but would still
+  have cloud sync disabled. Connecting a project to the cloud is an
+  explicit opt-in, so those flags now get flipped to true every time.
+
 ## [1.4.0] - 2026-04-05
 
 ### Added

--- a/src/cli/commands/cloud-connect.ts
+++ b/src/cli/commands/cloud-connect.ts
@@ -85,6 +85,27 @@ function updateConfigFile(projectRoot: string, projectId: string): boolean {
     if (/cloud\s*:\s*\{/.test(content)) {
       // Update existing projectId
       content = content.replace(/projectId\s*:\s*['"][^'"]*['"]/, `projectId: '${projectId}'`);
+
+      // Upsert enabled: true. `cloud connect` is an explicit opt-in to
+      // real-time cloud sync, so any existing `enabled: false` must
+      // flip to true. If the field is missing, insert it after the
+      // cloud: { opening brace.
+      if (/enabled\s*:\s*(?:true|false)/.test(content)) {
+        content = content.replace(/enabled\s*:\s*false/, 'enabled: true');
+      } else {
+        content = content.replace(/(cloud\s*:\s*\{\s*\n)/, `$1    enabled: true,\n`);
+      }
+
+      // Upsert autoSync: true for the same reason — `cloud connect`
+      // should opt the project into real-time streaming by default.
+      if (/autoSync\s*:\s*(?:true|false)/.test(content)) {
+        content = content.replace(/autoSync\s*:\s*false/, 'autoSync: true');
+      } else {
+        content = content.replace(
+          /(projectId\s*:\s*['"][^'"]*['"],?\s*\n)/,
+          `$1    autoSync: true,\n`,
+        );
+      }
     } else {
       // Ensure the last property before }); has a trailing comma
       content = content.replace(/(\s*)(}|])\s*\n(\}\);?\s*)$/, '$1$2,\n$3');

--- a/src/cloud/config-pusher.ts
+++ b/src/cloud/config-pusher.ts
@@ -41,6 +41,12 @@ interface ResolvedConfigFile {
   resolvedAt?: string;
   language?: string;
   framework?: string;
+  cloud?: {
+    enabled?: boolean;
+    autoSync?: boolean;
+    projectId?: string;
+    excludePaths?: string[];
+  };
 }
 
 /**
@@ -116,6 +122,19 @@ export function buildPayload(
       resolvedAt: resolved.resolvedAt ?? new Date().toISOString(),
     },
   };
+  // Include the cloud config block so the dashboard can render the
+  // real-time sync state ("Cloud sync: enabled" / "disabled") in the
+  // resolved-config summary. Never ship an empty object — the
+  // dashboard's parseConfigSnapshot keeps cloud=undefined semantics
+  // equivalent to "not configured" if no fields are present.
+  if (resolved.cloud && Object.keys(resolved.cloud).length > 0) {
+    payload.configSnapshot.cloud = {
+      enabled: resolved.cloud.enabled,
+      autoSync: resolved.cloud.autoSync,
+      projectId: resolved.cloud.projectId,
+      excludePaths: resolved.cloud.excludePaths,
+    };
+  }
   if (resolved.language) payload.language = resolved.language;
   if (resolved.framework) payload.framework = resolved.framework;
   return payload;

--- a/src/types.ts
+++ b/src/types.ts
@@ -224,6 +224,17 @@ export interface ProjectConfigPushPayload {
     agents: string[];
     profile?: string;
     resolvedAt: string;
+    /**
+     * Cloud sync config as declared in vguard.config.ts. Pushed so the
+     * dashboard can render "Cloud sync: enabled" and the project's live
+     * sync state in the resolved-config summary.
+     */
+    cloud?: {
+      enabled?: boolean;
+      autoSync?: boolean;
+      projectId?: string;
+      excludePaths?: string[];
+    };
   };
   /** Primary language of the consumer codebase (e.g. "typescript") */
   language?: string;

--- a/tests/cloud/config-pusher.test.ts
+++ b/tests/cloud/config-pusher.test.ts
@@ -144,3 +144,55 @@ describe('config-pusher hash stability', () => {
     expect(hashPayload(withLang)).toBe(hashPayload(basePayload));
   });
 });
+
+describe('config-pusher cloud section', () => {
+  it('includes cloud config when present in resolved file', () => {
+    const payload = buildPayload(
+      {
+        cloud: {
+          enabled: true,
+          autoSync: true,
+          projectId: 'proj_123',
+          excludePaths: ['node_modules/**'],
+        },
+      },
+      '1.4.1',
+    );
+    expect(payload.configSnapshot.cloud).toEqual({
+      enabled: true,
+      autoSync: true,
+      projectId: 'proj_123',
+      excludePaths: ['node_modules/**'],
+    });
+  });
+
+  it('omits cloud when not in resolved file', () => {
+    const payload = buildPayload({}, '1.4.1');
+    expect(payload.configSnapshot.cloud).toBeUndefined();
+  });
+
+  it('omits cloud when resolved file has empty cloud object', () => {
+    const payload = buildPayload({ cloud: {} }, '1.4.1');
+    expect(payload.configSnapshot.cloud).toBeUndefined();
+  });
+
+  it('propagates partial cloud config (undefined fields stay undefined)', () => {
+    const payload = buildPayload({ cloud: { enabled: true, autoSync: true } }, '1.4.1');
+    expect(payload.configSnapshot.cloud?.enabled).toBe(true);
+    expect(payload.configSnapshot.cloud?.autoSync).toBe(true);
+    expect(payload.configSnapshot.cloud?.projectId).toBeUndefined();
+    expect(payload.configSnapshot.cloud?.excludePaths).toBeUndefined();
+  });
+
+  it('changes hash when cloud.enabled flips', () => {
+    const enabled = buildPayload({ cloud: { enabled: true, autoSync: true } }, '1.4.1');
+    const disabled = buildPayload({ cloud: { enabled: false, autoSync: true } }, '1.4.1');
+    expect(hashPayload(enabled)).not.toBe(hashPayload(disabled));
+  });
+
+  it('changes hash when cloud.autoSync flips', () => {
+    const on = buildPayload({ cloud: { enabled: true, autoSync: true } }, '1.4.1');
+    const off = buildPayload({ cloud: { enabled: true, autoSync: false } }, '1.4.1');
+    expect(hashPayload(on)).not.toBe(hashPayload(off));
+  });
+});


### PR DESCRIPTION
## Summary

Closes two gaps in the 1.4.0 config-snapshot sync that kept projects showing as **"Cloud sync: disabled"** on the dashboard even when real-time streaming was working end-to-end.

## Bug #1 — `cloud` field omitted from payload

\`buildPayload()\` built \`{ presets, rules, agents, profile, resolvedAt }\` with no \`cloud\` field, so the server stored \`config_snapshot.cloud\` as \`undefined\`. The dashboard's [config.ts:170](../../vibe-guard-cloud/blob/master/src/lib/data/config.ts#L170) reads \`config.cloud?.autoSync\` and rendered "Cloud sync: disabled" for every project, regardless of whether their rule-hit streamer was actually running.

**Fix:** \`buildPayload()\` now includes the cloud block (\`enabled\`, \`autoSync\`, \`projectId\`, \`excludePaths\`) in every push when it's present in the resolved config. Empty \`cloud: {}\` objects are still omitted so truly-unconfigured projects keep "not configured" semantics.

## Bug #2 — `cloud connect` never flipped `enabled`/`autoSync` to true

When a \`cloud: {}\` block already existed in \`vguard.config.ts\`, [cloud-connect.ts:85-87](https://github.com/solanticai/vibe-guard/blob/dev/src/cli/commands/cloud-connect.ts#L85-L87) only updated \`projectId\`. A user who had set \`enabled: false\` (or who ran an older version that wrote it) and then ran \`cloud connect\` would get their ID updated but sync would stay off.

**Fix:** \`cloud connect\` now upserts \`enabled: true\` + \`autoSync: true\` into the existing block. Connecting a project to the cloud is an explicit opt-in, so those flags flip every time the command runs.

## Test plan

- [x] 6 new tests in \`tests/cloud/config-pusher.test.ts\` covering cloud-field inclusion/omission/hashing
- [x] 694/694 tests passing
- [x] \`npm run type-check\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run format:check\` clean
- [ ] After merge + 1.4.1 release: upgrade lumioh-operations, make one Edit, verify dashboard flips from "Cloud sync: disabled" to "Cloud sync: enabled"

Target ship: \`@solanticai/vguard@1.4.1\` (patch).