### PR TITLE
feat(cli): expose all CLI commands as project scripts + COMMANDS.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-04-05
+
+### Added
+
+- `vguard init` now exposes **every** VGuard CLI command as a namespaced
+  `vguard:*` script in the project's `package.json`. Previously only six
+  commands were injected (`lint`, `fix`, `doctor`, `sync`, `report`, and
+  the base `vguard` alias); now all 16 commands are registered — including
+  `vguard:generate`, `vguard:learn`, `vguard:upgrade`, `vguard:eject`,
+  `vguard:add`, `vguard:remove`, and the four `vguard:cloud:*` subcommands.
+  Users can run `npm run vguard:<cmd>` for any command without having to
+  remember the full CLI surface.
+- `.vguard/COMMANDS.md` is now generated on `vguard init` and refreshed on
+  `vguard generate`. This is a universal reference file that lists every
+  CLI command grouped by category (Setup, Quality, Analysis, Maintenance,
+  Cloud) with its description, npm script shortcut, and argument-
+  passthrough hints. It also serves projects that don't have a
+  `package.json` ("the project's equivalent file"), giving every project
+  a single, local, discoverable index of every VGuard command.
+- `vguard generate` now refreshes the `vguard:*` scripts list and rewrites
+  `.vguard/COMMANDS.md` as part of its normal flow. This ensures that new
+  commands added in future VGuard releases automatically surface in
+  existing projects the next time they regenerate their hooks — no manual
+  `package.json` edits required.
+
+### Changed
+
+- The command registry has moved to `src/utils/command-registry.ts` as a
+  single source of truth shared by `init`, `generate`, and the
+  `COMMANDS.md` renderer. Additions to the CLI only need to be registered
+  in one place to appear across all surfaces.
+
 ## [1.4.1] - 2026-04-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solanticai/vguard",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "AI coding guardrails framework. Runtime-enforced quality controls for Claude Code, Cursor, Codex, and more.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -15,6 +15,7 @@ import { codexAdapter } from '../../adapters/codex/adapter.js';
 import { openCodeAdapter } from '../../adapters/opencode/adapter.js';
 import { githubActionsAdapter } from '../../adapters/github-actions/adapter.js';
 import { mergeSettings } from '../../adapters/claude-code/settings-merger.js';
+import { applyProjectIntegrations } from '../../utils/project-scripts.js';
 import type { VGuardConfig, GeneratedFile } from '../../types.js';
 
 export async function generateCommand(): Promise<void> {
@@ -83,6 +84,10 @@ export async function generateCommand(): Promise<void> {
   // GitHub Actions is always generated if any agent is configured
   const gaFiles = await githubActionsAdapter.generate(resolvedConfig, projectRoot);
   for (const file of gaFiles) await writeGeneratedFile(file);
+
+  // Refresh project scripts (package.json) + COMMANDS.md reference so new
+  // VGuard commands propagate to existing projects on upgrade.
+  await applyProjectIntegrations(projectRoot, { interactive: false });
 
   const ruleCount = Array.from(resolvedConfig.rules.values()).filter((r) => r.enabled).length;
   console.log(`\n  Generated output for ${ruleCount} active rules.\n`);

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -17,6 +17,7 @@ import { codexAdapter } from '../../adapters/codex/adapter.js';
 import { openCodeAdapter } from '../../adapters/opencode/adapter.js';
 import { githubActionsAdapter } from '../../adapters/github-actions/adapter.js';
 import { mergeSettings } from '../../adapters/claude-code/settings-merger.js';
+import { applyProjectIntegrations } from '../../utils/project-scripts.js';
 
 export async function initCommand(): Promise<void> {
   const projectRoot = process.cwd();
@@ -224,8 +225,8 @@ export default defineConfig(${JSON.stringify(config, null, 2)});
     for (const file of gaFiles) await writeGeneratedFile(file);
   }
 
-  // Offer to add convenience npm scripts
-  await injectNpmScripts(projectRoot);
+  // Write COMMANDS.md reference + offer to add convenience npm scripts
+  await applyProjectIntegrations(projectRoot, { interactive: true });
 
   // Summary
   const ruleCount = resolvedConfig.rules.size;
@@ -271,59 +272,6 @@ function buildFolderChoices(selectedAgents: AgentType[]) {
   });
 
   return choices;
-}
-
-/**
- * Offer to inject VGuard convenience scripts into the project's package.json.
- * This allows running `npm run vguard:lint` instead of `npx vguard lint`.
- */
-async function injectNpmScripts(projectRoot: string): Promise<void> {
-  const pkgPath = join(projectRoot, 'package.json');
-  if (!existsSync(pkgPath)) return;
-
-  const scriptAnswer = await inquirer.prompt([
-    {
-      type: 'confirm',
-      name: 'addScripts',
-      message: 'Add VGuard convenience scripts to package.json?',
-      default: true,
-    },
-  ]);
-
-  if (!scriptAnswer.addScripts) return;
-
-  try {
-    const raw = readFileSync(pkgPath, 'utf-8');
-    const pkg = JSON.parse(raw);
-    const existing = pkg.scripts ?? {};
-
-    const newScripts: Record<string, string> = {
-      vguard: 'vguard',
-      'vguard:lint': 'vguard lint',
-      'vguard:fix': 'vguard fix',
-      'vguard:doctor': 'vguard doctor',
-      'vguard:sync': 'vguard sync',
-      'vguard:report': 'vguard report',
-    };
-
-    let added = 0;
-    for (const [key, value] of Object.entries(newScripts)) {
-      if (!(key in existing)) {
-        existing[key] = value;
-        added++;
-      }
-    }
-
-    if (added > 0) {
-      pkg.scripts = existing;
-      await writeFile(pkgPath, JSON.stringify(pkg, null, 2) + '\n', 'utf-8');
-      console.log(`  Added ${added} VGuard scripts to package.json`);
-    } else {
-      console.log('  VGuard scripts already present in package.json');
-    }
-  } catch {
-    // Non-critical — skip silently
-  }
 }
 
 function detectFramework(projectRoot: string): string | null {

--- a/src/utils/command-registry.ts
+++ b/src/utils/command-registry.ts
@@ -1,0 +1,207 @@
+/**
+ * Single source of truth for all VGuard CLI commands exposed as project scripts.
+ *
+ * This registry is used by:
+ *  - {@link injectPackageJsonScripts} — to add `vguard:*` npm scripts to the user's
+ *    project `package.json`.
+ *  - {@link writeCommandsReference} — to generate `.vguard/COMMANDS.md`, a universal
+ *    reference file that works for projects without a `package.json`.
+ *
+ * Keep this list in sync with the command definitions in `src/cli/index.ts`.
+ */
+
+export type CommandCategory = 'setup' | 'quality' | 'analysis' | 'maintenance' | 'cloud';
+
+export interface VguardCommand {
+  /** npm script key, e.g. `vguard:lint`. */
+  scriptName: string;
+  /** The shell invocation the script maps to, e.g. `vguard lint`. */
+  cliInvocation: string;
+  /** Human-readable description surfaced in COMMANDS.md. */
+  description: string;
+  /** Grouping used to organise the markdown reference file. */
+  category: CommandCategory;
+  /**
+   * `true` when the command requires a positional argument.
+   * Users invoke these via npm's `--` passthrough:
+   *   `npm run vguard:add -- security/branch-protection`
+   */
+  acceptsArgs?: boolean;
+  /** Optional hint surfaced next to the command in COMMANDS.md. */
+  notes?: string;
+}
+
+export const VGUARD_COMMANDS: readonly VguardCommand[] = [
+  // --- Setup -------------------------------------------------------------
+  {
+    scriptName: 'vguard',
+    cliInvocation: 'vguard',
+    description: 'Print help and the list of available VGuard commands.',
+    category: 'setup',
+  },
+  {
+    scriptName: 'vguard:init',
+    cliInvocation: 'vguard init',
+    description: 'Interactive setup wizard — configure VGuard for this project.',
+    category: 'setup',
+  },
+  {
+    scriptName: 'vguard:generate',
+    cliInvocation: 'vguard generate',
+    description:
+      'Regenerate hook scripts, agent configs, and project scripts from vguard.config.ts.',
+    category: 'setup',
+  },
+  {
+    scriptName: 'vguard:doctor',
+    cliInvocation: 'vguard doctor',
+    description: 'Validate config, hook health, and performance budget.',
+    category: 'setup',
+  },
+
+  // --- Quality -----------------------------------------------------------
+  {
+    scriptName: 'vguard:lint',
+    cliInvocation: 'vguard lint',
+    description: 'Run rules in static-analysis mode (CI-friendly).',
+    category: 'quality',
+    notes: 'Pass --format text|json|github-actions via `npm run vguard:lint -- --format json`.',
+  },
+  {
+    scriptName: 'vguard:fix',
+    cliInvocation: 'vguard fix',
+    description: 'Auto-fix issues that have machine-applicable fixes.',
+    category: 'quality',
+    notes: 'Use --dry-run to preview fixes: `npm run vguard:fix -- --dry-run`.',
+  },
+
+  // --- Analysis ----------------------------------------------------------
+  {
+    scriptName: 'vguard:learn',
+    cliInvocation: 'vguard learn',
+    description: 'Scan the codebase for conventions and suggest new rules.',
+    category: 'analysis',
+  },
+  {
+    scriptName: 'vguard:report',
+    cliInvocation: 'vguard report',
+    description: 'Generate a quality dashboard from accumulated rule-hit data.',
+    category: 'analysis',
+  },
+
+  // --- Maintenance -------------------------------------------------------
+  {
+    scriptName: 'vguard:add',
+    cliInvocation: 'vguard add',
+    description: 'Add a rule or preset to vguard.config.ts.',
+    category: 'maintenance',
+    acceptsArgs: true,
+    notes: 'Example: `npm run vguard:add -- security/branch-protection`.',
+  },
+  {
+    scriptName: 'vguard:remove',
+    cliInvocation: 'vguard remove',
+    description: 'Remove a rule or preset from vguard.config.ts.',
+    category: 'maintenance',
+    acceptsArgs: true,
+    notes: 'Example: `npm run vguard:remove -- preset:nextjs-15`.',
+  },
+  {
+    scriptName: 'vguard:upgrade',
+    cliInvocation: 'vguard upgrade',
+    description: 'Check for and apply updates to VGuard and plugins.',
+    category: 'maintenance',
+    notes: 'Pass --check or --apply: `npm run vguard:upgrade -- --check`.',
+  },
+  {
+    scriptName: 'vguard:eject',
+    cliInvocation: 'vguard eject',
+    description: 'Export standalone hook scripts (removes the VGuard dependency).',
+    category: 'maintenance',
+    notes: 'Supports --adapter and --output flags via `--`.',
+  },
+
+  // --- Cloud -------------------------------------------------------------
+  {
+    scriptName: 'vguard:sync',
+    cliInvocation: 'vguard sync',
+    description: 'Upload rule-hit data and the config snapshot to VGuard Cloud.',
+    category: 'cloud',
+    notes: 'Pass --force or --dry-run: `npm run vguard:sync -- --dry-run`.',
+  },
+  {
+    scriptName: 'vguard:cloud:login',
+    cliInvocation: 'vguard cloud login',
+    description: 'Authenticate with VGuard Cloud (opens browser by default).',
+    category: 'cloud',
+  },
+  {
+    scriptName: 'vguard:cloud:logout',
+    cliInvocation: 'vguard cloud logout',
+    description: 'Remove stored Cloud credentials from this machine.',
+    category: 'cloud',
+  },
+  {
+    scriptName: 'vguard:cloud:connect',
+    cliInvocation: 'vguard cloud connect',
+    description: 'Register the current repository with VGuard Cloud.',
+    category: 'cloud',
+  },
+  {
+    scriptName: 'vguard:cloud:status',
+    cliInvocation: 'vguard cloud status',
+    description: 'Show the current VGuard Cloud connection status.',
+    category: 'cloud',
+  },
+] as const;
+
+/**
+ * Human-readable labels for each category, used as section headings in
+ * `.vguard/COMMANDS.md`.
+ */
+export const CATEGORY_LABELS: Record<CommandCategory, string> = {
+  setup: 'Setup & Configuration',
+  quality: 'Quality Checks',
+  analysis: 'Analysis & Reporting',
+  maintenance: 'Rules & Maintenance',
+  cloud: 'VGuard Cloud',
+};
+
+/**
+ * The canonical ordering of categories in generated output.
+ */
+export const CATEGORY_ORDER: readonly CommandCategory[] = [
+  'setup',
+  'quality',
+  'analysis',
+  'maintenance',
+  'cloud',
+] as const;
+
+/**
+ * Group commands by their category while preserving registry order within each group.
+ */
+export function getCommandsByCategory(): Record<CommandCategory, VguardCommand[]> {
+  const grouped: Record<CommandCategory, VguardCommand[]> = {
+    setup: [],
+    quality: [],
+    analysis: [],
+    maintenance: [],
+    cloud: [],
+  };
+  for (const cmd of VGUARD_COMMANDS) {
+    grouped[cmd.category].push(cmd);
+  }
+  return grouped;
+}
+
+/**
+ * Build a flat `{ scriptName: cliInvocation }` record for package.json injection.
+ */
+export function buildScriptsRecord(): Record<string, string> {
+  const scripts: Record<string, string> = {};
+  for (const cmd of VGUARD_COMMANDS) {
+    scripts[cmd.scriptName] = cmd.cliInvocation;
+  }
+  return scripts;
+}

--- a/src/utils/project-scripts.ts
+++ b/src/utils/project-scripts.ts
@@ -1,0 +1,221 @@
+/**
+ * Project-level integration helpers for VGuard.
+ *
+ * - {@link injectPackageJsonScripts} — adds every `vguard:*` npm script to the
+ *   user's `package.json` (additively, never overwriting existing keys).
+ * - {@link writeCommandsReference} — writes `.vguard/COMMANDS.md`, a universal
+ *   reference file listing every command, its description, and its npm script
+ *   shortcut. Works for any project, including those without a `package.json`.
+ * - {@link applyProjectIntegrations} — combined entry point used by
+ *   `vguard init` (interactive) and `vguard generate` (silent refresh).
+ */
+
+import inquirer from 'inquirer';
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+import {
+  CATEGORY_LABELS,
+  CATEGORY_ORDER,
+  buildScriptsRecord,
+  getCommandsByCategory,
+} from './command-registry.js';
+
+export interface InjectResult {
+  /** Number of scripts newly added to package.json. */
+  added: number;
+  /** Number of scripts already present and left untouched. */
+  skipped: number;
+  /** `true` when no package.json exists in the project root. */
+  noPackageJson: boolean;
+}
+
+/**
+ * Inject the full set of `vguard:*` scripts into the project's package.json.
+ *
+ * Behaviour:
+ *  - Never overwrites an existing script key.
+ *  - Silently no-ops if `package.json` is missing or unreadable (fail-open).
+ *  - Preserves the existing field order as produced by JSON.parse.
+ */
+export async function injectPackageJsonScripts(projectRoot: string): Promise<InjectResult> {
+  const pkgPath = join(projectRoot, 'package.json');
+
+  if (!existsSync(pkgPath)) {
+    return { added: 0, skipped: 0, noPackageJson: true };
+  }
+
+  let pkg: { scripts?: Record<string, string>; [key: string]: unknown };
+  try {
+    const raw = readFileSync(pkgPath, 'utf-8');
+    pkg = JSON.parse(raw);
+  } catch {
+    // Malformed package.json — fail open, leave untouched.
+    return { added: 0, skipped: 0, noPackageJson: false };
+  }
+
+  const existing: Record<string, string> = pkg.scripts ?? {};
+  const desired = buildScriptsRecord();
+
+  let added = 0;
+  let skipped = 0;
+
+  for (const [key, value] of Object.entries(desired)) {
+    if (key in existing) {
+      skipped++;
+    } else {
+      existing[key] = value;
+      added++;
+    }
+  }
+
+  if (added === 0) {
+    return { added: 0, skipped, noPackageJson: false };
+  }
+
+  pkg.scripts = existing;
+
+  try {
+    await writeFile(pkgPath, JSON.stringify(pkg, null, 2) + '\n', 'utf-8');
+  } catch {
+    // Write failure — fail open.
+    return { added: 0, skipped, noPackageJson: false };
+  }
+
+  return { added, skipped, noPackageJson: false };
+}
+
+/**
+ * Write `.vguard/COMMANDS.md`, a grouped reference of every VGuard CLI command.
+ *
+ * Always writes (overwrites) the file. This keeps the reference in sync with
+ * the registry across VGuard upgrades.
+ */
+export async function writeCommandsReference(projectRoot: string): Promise<void> {
+  const outPath = join(projectRoot, '.vguard', 'COMMANDS.md');
+  const content = renderCommandsMarkdown();
+
+  await mkdir(dirname(outPath), { recursive: true });
+  await writeFile(outPath, content, 'utf-8');
+}
+
+/**
+ * Render the markdown body of `.vguard/COMMANDS.md`.
+ *
+ * Exposed for testing.
+ */
+export function renderCommandsMarkdown(): string {
+  const grouped = getCommandsByCategory();
+  const lines: string[] = [];
+
+  lines.push('# VGuard — Project Commands');
+  lines.push('');
+  lines.push(
+    'Every VGuard CLI command is available as an npm script in this project. Run any command with:',
+  );
+  lines.push('');
+  lines.push('```bash');
+  lines.push('npm run vguard:<command>');
+  lines.push('# or, for a specific argument:');
+  lines.push('npm run vguard:add -- security/branch-protection');
+  lines.push('```');
+  lines.push('');
+  lines.push('> This file is regenerated automatically by `vguard init` and `vguard generate`.');
+  lines.push('> Do not edit it by hand — your changes will be overwritten.');
+  lines.push('');
+
+  for (const category of CATEGORY_ORDER) {
+    const commands = grouped[category];
+    if (commands.length === 0) continue;
+
+    lines.push(`## ${CATEGORY_LABELS[category]}`);
+    lines.push('');
+    lines.push('| npm script | CLI command | Description |');
+    lines.push('| --- | --- | --- |');
+
+    for (const cmd of commands) {
+      const invocation = cmd.acceptsArgs ? `${cmd.cliInvocation} <arg>` : cmd.cliInvocation;
+      const description = cmd.notes ? `${cmd.description}<br>_${cmd.notes}_` : cmd.description;
+      lines.push(`| \`npm run ${cmd.scriptName}\` | \`${invocation}\` | ${description} |`);
+    }
+
+    lines.push('');
+  }
+
+  lines.push('---');
+  lines.push('');
+  lines.push('To pass flags or arguments to any command, use the npm `--` separator. For example:');
+  lines.push('');
+  lines.push('```bash');
+  lines.push('npm run vguard:lint -- --format json');
+  lines.push('npm run vguard:upgrade -- --check');
+  lines.push('npm run vguard:sync -- --dry-run');
+  lines.push('```');
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+export interface ApplyIntegrationsOptions {
+  /**
+   * When `true`, prompt the user before modifying `package.json`.
+   * Used by `vguard init`.
+   *
+   * When `false`, apply changes silently. Used by `vguard generate` to
+   * keep scripts + COMMANDS.md in sync as VGuard versions add new commands.
+   */
+  interactive: boolean;
+}
+
+/**
+ * Combined entry point used by both `init` and `generate` commands.
+ */
+export async function applyProjectIntegrations(
+  projectRoot: string,
+  options: ApplyIntegrationsOptions,
+): Promise<void> {
+  // Always write the universal reference file — it's the only guaranteed
+  // "view all commands" surface for projects without a package.json.
+  try {
+    await writeCommandsReference(projectRoot);
+    if (!options.interactive) {
+      console.log('  Refreshed .vguard/COMMANDS.md');
+    } else {
+      console.log('  Created .vguard/COMMANDS.md — see it for a full command reference');
+    }
+  } catch {
+    // Non-critical — skip silently.
+  }
+
+  const pkgPath = join(projectRoot, 'package.json');
+  if (!existsSync(pkgPath)) return;
+
+  let shouldInject = true;
+
+  if (options.interactive) {
+    const answer = await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'addScripts',
+        message: 'Add VGuard command shortcuts to package.json?',
+        default: true,
+      },
+    ]);
+    shouldInject = Boolean(answer.addScripts);
+  }
+
+  if (!shouldInject) return;
+
+  const result = await injectPackageJsonScripts(projectRoot);
+
+  if (options.interactive) {
+    if (result.added > 0) {
+      console.log(`  Added ${result.added} VGuard scripts to package.json`);
+    } else if (result.skipped > 0) {
+      console.log('  VGuard scripts already present in package.json');
+    }
+  } else if (result.added > 0) {
+    console.log(`  Added ${result.added} new VGuard scripts to package.json`);
+  }
+}

--- a/tests/utils/project-scripts.test.ts
+++ b/tests/utils/project-scripts.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  injectPackageJsonScripts,
+  writeCommandsReference,
+  renderCommandsMarkdown,
+} from '../../src/utils/project-scripts.js';
+import { VGUARD_COMMANDS } from '../../src/utils/command-registry.js';
+
+describe('utils/project-scripts', () => {
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    projectRoot = await mkdtemp(join(tmpdir(), 'vguard-project-scripts-'));
+  });
+
+  afterEach(async () => {
+    await rm(projectRoot, { recursive: true, force: true });
+  });
+
+  describe('injectPackageJsonScripts', () => {
+    it('adds every vguard:* script when package.json has no scripts', async () => {
+      const pkgPath = join(projectRoot, 'package.json');
+      await writeFile(pkgPath, JSON.stringify({ name: 'fixture', version: '0.0.0' }), 'utf-8');
+
+      const result = await injectPackageJsonScripts(projectRoot);
+
+      expect(result.noPackageJson).toBe(false);
+      expect(result.added).toBe(VGUARD_COMMANDS.length);
+      expect(result.skipped).toBe(0);
+
+      const written = JSON.parse(await readFile(pkgPath, 'utf-8'));
+      expect(Object.keys(written.scripts)).toHaveLength(VGUARD_COMMANDS.length);
+
+      for (const cmd of VGUARD_COMMANDS) {
+        expect(written.scripts[cmd.scriptName]).toBe(cmd.cliInvocation);
+      }
+    });
+
+    it('leaves existing scripts untouched and reports them as skipped', async () => {
+      const pkgPath = join(projectRoot, 'package.json');
+      await writeFile(
+        pkgPath,
+        JSON.stringify({
+          name: 'fixture',
+          version: '0.0.0',
+          scripts: {
+            'vguard:lint': 'custom-lint-command',
+            test: 'jest',
+          },
+        }),
+        'utf-8',
+      );
+
+      const result = await injectPackageJsonScripts(projectRoot);
+
+      expect(result.added).toBe(VGUARD_COMMANDS.length - 1);
+      expect(result.skipped).toBe(1);
+
+      const written = JSON.parse(await readFile(pkgPath, 'utf-8'));
+      // User's custom script is preserved.
+      expect(written.scripts['vguard:lint']).toBe('custom-lint-command');
+      // Unrelated scripts are preserved.
+      expect(written.scripts.test).toBe('jest');
+    });
+
+    it('is idempotent when run a second time', async () => {
+      const pkgPath = join(projectRoot, 'package.json');
+      await writeFile(pkgPath, JSON.stringify({ name: 'fixture', version: '0.0.0' }), 'utf-8');
+
+      const first = await injectPackageJsonScripts(projectRoot);
+      const second = await injectPackageJsonScripts(projectRoot);
+
+      expect(first.added).toBe(VGUARD_COMMANDS.length);
+      expect(second.added).toBe(0);
+      expect(second.skipped).toBe(VGUARD_COMMANDS.length);
+    });
+
+    it('no-ops silently when package.json is missing', async () => {
+      const result = await injectPackageJsonScripts(projectRoot);
+
+      expect(result.noPackageJson).toBe(true);
+      expect(result.added).toBe(0);
+      expect(result.skipped).toBe(0);
+    });
+
+    it('fails open on malformed package.json', async () => {
+      const pkgPath = join(projectRoot, 'package.json');
+      await writeFile(pkgPath, '{ not valid json', 'utf-8');
+
+      const result = await injectPackageJsonScripts(projectRoot);
+
+      expect(result.noPackageJson).toBe(false);
+      expect(result.added).toBe(0);
+      expect(result.skipped).toBe(0);
+
+      // Original content is preserved.
+      const content = await readFile(pkgPath, 'utf-8');
+      expect(content).toBe('{ not valid json');
+    });
+
+    it('writes package.json with a trailing newline', async () => {
+      const pkgPath = join(projectRoot, 'package.json');
+      await writeFile(pkgPath, JSON.stringify({ name: 'fixture', version: '0.0.0' }), 'utf-8');
+
+      await injectPackageJsonScripts(projectRoot);
+
+      const content = await readFile(pkgPath, 'utf-8');
+      expect(content.endsWith('\n')).toBe(true);
+    });
+  });
+
+  describe('writeCommandsReference', () => {
+    it('creates .vguard/COMMANDS.md at the project root', async () => {
+      await writeCommandsReference(projectRoot);
+
+      const outPath = join(projectRoot, '.vguard', 'COMMANDS.md');
+      expect(existsSync(outPath)).toBe(true);
+    });
+
+    it('includes every command from the registry', async () => {
+      await writeCommandsReference(projectRoot);
+
+      const content = await readFile(join(projectRoot, '.vguard', 'COMMANDS.md'), 'utf-8');
+      for (const cmd of VGUARD_COMMANDS) {
+        expect(content).toContain(cmd.scriptName);
+        expect(content).toContain(cmd.description);
+      }
+    });
+
+    it('overwrites existing COMMANDS.md', async () => {
+      await writeCommandsReference(projectRoot);
+      const outPath = join(projectRoot, '.vguard', 'COMMANDS.md');
+      await writeFile(outPath, 'stale content', 'utf-8');
+
+      await writeCommandsReference(projectRoot);
+
+      const content = await readFile(outPath, 'utf-8');
+      expect(content).not.toBe('stale content');
+      expect(content).toContain('VGuard — Project Commands');
+    });
+  });
+
+  describe('renderCommandsMarkdown', () => {
+    it('produces markdown with all category sections', () => {
+      const md = renderCommandsMarkdown();
+
+      expect(md).toContain('# VGuard — Project Commands');
+      expect(md).toContain('## Setup & Configuration');
+      expect(md).toContain('## Quality Checks');
+      expect(md).toContain('## Analysis & Reporting');
+      expect(md).toContain('## Rules & Maintenance');
+      expect(md).toContain('## VGuard Cloud');
+    });
+
+    it('documents the npm passthrough pattern for argument-taking commands', () => {
+      const md = renderCommandsMarkdown();
+
+      expect(md).toContain('npm run vguard:add -- security/branch-protection');
+    });
+
+    it('includes the regeneration warning comment', () => {
+      const md = renderCommandsMarkdown();
+      expect(md).toContain('regenerated automatically');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Expose every VGuard CLI command as a namespaced `vguard:*` npm script in the user's `package.json`, plus generate `.vguard/COMMANDS.md` as a universal reference file. Previously only six commands were injected on `vguard init`; users had to look up the rest externally. Now all 16 commands — including `generate`, `learn`, `upgrade`, `eject`, `add`, `remove`, and the four `cloud:*` subcommands — are discoverable and triggerable from within the project itself.

**Version:** 1.4.1 → **1.5.0** (minor bump — new feature).

## What Changed

- **New** `src/utils/command-registry.ts` — single source of truth for all 16 CLI commands + the base `vguard` alias, shared by `init`, `generate`, and the markdown renderer.
- **New** `src/utils/project-scripts.ts` — exposes `injectPackageJsonScripts` (additive-only, never overwrites user-customised scripts, fails open on malformed `package.json`), `writeCommandsReference` (writes `.vguard/COMMANDS.md` grouped by Setup / Quality / Analysis / Maintenance / Cloud), and `applyProjectIntegrations` (interactive from `init`, silent refresh from `generate`).
- **Refactor** `src/cli/commands/init.ts` — removed inline six-command injection, now delegates to `applyProjectIntegrations`.
- **Update** `src/cli/commands/generate.ts` — refreshes scripts + COMMANDS.md on every run, so new CLI commands added in future VGuard releases automatically surface in existing projects.
- **New** `tests/utils/project-scripts.test.ts` — 12 tests covering additive injection, idempotency, missing `package.json`, malformed JSON (fail-open), and markdown rendering.
- **CHANGELOG.md** — new `[1.5.0]` entry.

## Why This Design

- **Argument-taking commands** (`add`, `remove`): included as plain scripts, invoked via npm's `--` passthrough (`npm run vguard:add -- security/branch-protection`). Documented in COMMANDS.md.
- **Option flags** (`--dry-run`, `--check`, etc.): single script per command, passthrough via `--`. Avoids script pollution.
- **Non-Node projects** ("the project's equivalent file"): `.vguard/COMMANDS.md` is always written — a universal, discoverable reference that doesn't require package-manager detection.
- **Self-healing**: running `vguard generate` re-injects any missing scripts and rewrites `COMMANDS.md`, so upgrades propagate automatically.

## Test Plan

- [x] `npm test` — 706 passing (12 new)
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run type-check` — clean
- [x] `npm run build` — builds both ESM + CJS

### Manual verification (post-merge)

- [ ] Run `npx @solanticai/vguard@1.5.0 init` in a scratch project with a `package.json` — verify ~17 `vguard:*` scripts appear and `.vguard/COMMANDS.md` is written.
- [ ] Run `npx vguard generate` a second time — verify no duplicate keys, `COMMANDS.md` refreshed.
- [ ] Run in a directory with no `package.json` — verify `.vguard/COMMANDS.md` still written without crash.
- [ ] Run `npm run vguard:add -- security/branch-protection` — verify argument passthrough works.