### PR TITLE
feat(sessions): capture session_id + lifecycle hooks end-to-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-04-05
+
+### Added
+
+- Session tracking: Claude Code's `session_id` hook payload is now
+  captured on every hook invocation and attached to every rule-hit
+  record. Previously `session_id` was silently discarded, which meant
+  every synced `rule_hits.session_id` on the cloud dashboard was null
+  and sessions could not be grouped, filtered, or drilled into.
+- New `SessionStart` and `SessionEnd` Claude Code hooks are generated
+  by the claude-code adapter. Both are always registered (regardless
+  of active rules) and run matcher-less. They write lifecycle markers
+  to `.vguard/data/session-events.jsonl` with branch, cli_version,
+  agent, and cwd metadata, then fire a best-effort flush to the new
+  cloud `/api/v1/sessions/events` endpoint.
+- New `session-tracker.ts` / `session-streamer.ts` modules maintain
+  an append-only JSONL log of session lifecycle events and stream
+  them to the cloud with cursor-based deduplication. Fail-open
+  throughout — session telemetry never blocks developer work.
+- `HookContext` now carries an optional `sessionId` field, so custom
+  rules can read the active session id if they need it (e.g. to
+  include it in messages or autofix metadata).
+
+### Changed
+
+- `RuleHitRecord` (the JSONL shape written to
+  `.vguard/data/rule-hits.jsonl`) now carries an optional `sessionId`
+  field. Existing records without `sessionId` remain valid.
+- `recordRuleHit()` gained an optional `sessionId` parameter. Call
+  sites inside the CLI pass the session id extracted from stdin;
+  the parameter is backward compatible for any external callers.
+- `vguard generate` refreshes `.claude/settings.json` to include the
+  new SessionStart/SessionEnd hook entries. Existing projects only
+  need to re-run `vguard generate` once to start forwarding session
+  lifecycle events.
+
 ## [1.4.1] - 2026-04-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solanticai/vguard",
-  "version": "1.4.1",
+  "version": "1.6.0",
   "description": "AI coding guardrails framework. Runtime-enforced quality controls for Claude Code, Cursor, Codex, and more.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/adapters/claude-code/adapter.ts
+++ b/src/adapters/claude-code/adapter.ts
@@ -5,7 +5,26 @@ import { generateCommands } from './command-generator.js';
 import { generateEnforcementRules } from './rules-generator.js';
 
 /** Hook event types that VGuard generates scripts for */
-const HOOK_EVENTS: HookEvent[] = ['PreToolUse', 'PostToolUse', 'Stop'];
+const HOOK_EVENTS: HookEvent[] = [
+  'PreToolUse',
+  'PostToolUse',
+  'Stop',
+  'SessionStart',
+  'SessionEnd',
+];
+
+/**
+ * Events that do not run rules and therefore do not need a tool matcher.
+ * These are recorded for telemetry only (session lifecycle + Stop flush).
+ */
+const MATCHERLESS_EVENTS = new Set<HookEvent>(['Stop', 'SessionStart', 'SessionEnd']);
+
+/**
+ * Events that should always be registered, even when no active rules
+ * reference them. Session lifecycle hooks exist purely to capture
+ * start/end markers for the cloud dashboard.
+ */
+const ALWAYS_REGISTERED_EVENTS: HookEvent[] = ['SessionStart', 'SessionEnd'];
 
 /**
  * Claude Code adapter.
@@ -44,6 +63,14 @@ export const claudeCodeAdapter: Adapter = {
             activeEvents.get(event)!.add(tool);
           }
         }
+      }
+    }
+
+    // Session lifecycle hooks are always registered — they capture
+    // telemetry even when no rules fire.
+    for (const event of ALWAYS_REGISTERED_EVENTS) {
+      if (!activeEvents.has(event)) {
+        activeEvents.set(event, new Set());
       }
     }
 
@@ -102,8 +129,9 @@ function buildSettingsHooks(
       ],
     };
 
-    // Add matcher for PreToolUse and PostToolUse (Stop has no matcher)
-    if (event !== 'Stop' && toolMatcher) {
+    // Matcher only applies to tool-based events (PreToolUse, PostToolUse).
+    // Stop, SessionStart, and SessionEnd have no tool context.
+    if (!MATCHERLESS_EVENTS.has(event) && toolMatcher) {
       hookEntry.matcher = toolMatcher;
     }
 

--- a/src/cloud/client.ts
+++ b/src/cloud/client.ts
@@ -92,6 +92,26 @@ export class CloudClient {
   }
 
   /**
+   * POST session lifecycle events (start/end) to the sessions endpoint.
+   * Uses project API key authentication. Events are NDJSON.
+   */
+  async postSessionEvents(
+    apiKey: string,
+    events: unknown[],
+  ): Promise<{ processed: number; starts: number; ends: number }> {
+    const body = events.map((e) => JSON.stringify(e)).join('\n');
+    const res = await this.request('/api/v1/sessions/events', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-ndjson',
+        'X-API-Key': apiKey,
+      },
+      body,
+    });
+    return res as { processed: number; starts: number; ends: number };
+  }
+
+  /**
    * Register a project with Cloud.
    * Returns the generated API key (shown once).
    */

--- a/src/cloud/session-streamer.ts
+++ b/src/cloud/session-streamer.ts
@@ -1,0 +1,134 @@
+/**
+ * Session event streamer.
+ *
+ * Reads pending session lifecycle events from `.vguard/data/session-events.jsonl`,
+ * POSTs them to /api/v1/sessions/events, and advances a cursor so the same
+ * events are not re-sent on the next call.
+ *
+ * Session events are low-volume (a handful per session) so we skip the
+ * batching / backoff complexity of the rule-hit streamer. Every flush
+ * sends all unsynced events and the server-side upsert is idempotent.
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import type { SessionEventRecord } from '../engine/session-tracker.js';
+
+const EVENTS_FILE = '.vguard/data/session-events.jsonl';
+const CURSOR_FILE = '.vguard/data/session-events.cursor.json';
+const DEFAULT_TIMEOUT_MS = 3_000;
+
+interface SessionCursor {
+  /** ISO timestamp of the last successfully uploaded event */
+  lastSyncedAt: string;
+}
+
+function readCursor(projectRoot: string): SessionCursor {
+  const filePath = join(projectRoot, CURSOR_FILE);
+  try {
+    if (existsSync(filePath)) {
+      return JSON.parse(readFileSync(filePath, 'utf-8')) as SessionCursor;
+    }
+  } catch {
+    // Corrupted — start fresh
+  }
+  return { lastSyncedAt: new Date(0).toISOString() };
+}
+
+function writeCursor(projectRoot: string, cursor: SessionCursor): void {
+  const filePath = join(projectRoot, CURSOR_FILE);
+  const tmpPath = filePath + '.tmp';
+  const dir = dirname(filePath);
+  try {
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    writeFileSync(tmpPath, JSON.stringify(cursor), 'utf-8');
+    renameSync(tmpPath, filePath);
+  } catch {
+    // Non-critical — will retry next call
+  }
+}
+
+/**
+ * Read all session events (current + rotated).
+ */
+function readSessionEvents(projectRoot: string): SessionEventRecord[] {
+  const logPath = join(projectRoot, EVENTS_FILE);
+  const oldPath = logPath + '.old';
+  const records: SessionEventRecord[] = [];
+
+  const parseFile = (path: string) => {
+    try {
+      if (!existsSync(path)) return;
+      const content = readFileSync(path, 'utf-8');
+      const lines = content.trim().split('\n').filter(Boolean);
+      for (const line of lines) {
+        try {
+          records.push(JSON.parse(line) as SessionEventRecord);
+        } catch {
+          // Skip bad lines
+        }
+      }
+    } catch {
+      // Fail open
+    }
+  };
+
+  parseFile(oldPath);
+  parseFile(logPath);
+  return records;
+}
+
+/**
+ * Flush any pending session events to the cloud. Fire-and-forget;
+ * errors are swallowed. Safe to call on every hook invocation.
+ */
+export async function flushSessionEvents(
+  projectRoot: string,
+  apiKey: string,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<void> {
+  try {
+    const cursor = readCursor(projectRoot);
+    const allEvents = readSessionEvents(projectRoot);
+    const cursorTime = new Date(cursor.lastSyncedAt).getTime();
+
+    const pending = allEvents.filter((e) => new Date(e.timestamp).getTime() > cursorTime);
+
+    if (pending.length === 0) return;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const body = pending.map((e) => JSON.stringify(e)).join('\n');
+      const url =
+        (process.env.VGUARD_CLOUD_URL ?? 'https://vguard.dev').replace(/\/$/, '') +
+        '/api/v1/sessions/events';
+
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-ndjson',
+          'X-API-Key': apiKey,
+        },
+        body,
+        signal: controller.signal,
+      });
+
+      clearTimeout(timer);
+
+      if (res.ok) {
+        const last = pending[pending.length - 1];
+        writeCursor(projectRoot, { lastSyncedAt: last.timestamp });
+      }
+    } catch {
+      clearTimeout(timer);
+      // Network error / timeout — try again next call
+    }
+  } catch {
+    // Outer catch — never propagate
+  }
+}

--- a/src/engine/context.ts
+++ b/src/engine/context.ts
@@ -8,6 +8,8 @@ import { isValidFilePath } from '../utils/validation.js';
 export interface RawHookInput {
   tool_name?: string;
   tool_input?: Record<string, unknown>;
+  /** Claude Code session identifier — forwarded onto HookContext + RuleHitRecord. */
+  session_id?: string;
   [key: string]: unknown;
 }
 
@@ -21,6 +23,10 @@ export function buildHookContext(
 ): HookContext {
   const tool = rawInput.tool_name ?? '';
   const toolInput = rawInput.tool_input ?? {};
+  const sessionId =
+    typeof rawInput.session_id === 'string' && rawInput.session_id.length > 0
+      ? rawInput.session_id
+      : undefined;
 
   // Extract file path for git context, validating it does not contain shell metacharacters
   const rawFilePath = (toolInput.file_path as string) ?? (toolInput.path as string) ?? '';
@@ -35,5 +41,6 @@ export function buildHookContext(
     toolInput,
     projectConfig: config,
     gitContext,
+    ...(sessionId !== undefined ? { sessionId } : {}),
   };
 }

--- a/src/engine/hook-entry.ts
+++ b/src/engine/hook-entry.ts
@@ -5,16 +5,21 @@
  * It reads stdin, builds context, resolves rules, runs them, and outputs results.
  */
 
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import type { HookEvent, CloudConfig } from '../types.js';
-import { parseStdinJson, extractToolInput } from '../utils/stdin.js';
+import { parseStdinJson, extractToolInput, extractSessionId } from '../utils/stdin.js';
 import { loadCompiledConfig } from '../config/compile.js';
 import { buildHookContext } from './context.js';
 import { resolveRules } from './resolver.js';
 import { runRules } from './runner.js';
 import { recordRuleHit } from './tracker.js';
+import { recordSessionEvent } from './session-tracker.js';
 import { recordPerfEntry } from './perf.js';
 import { formatPreToolUseOutput, formatPostToolUseOutput, formatStopOutput } from './output.js';
 import { isValidHookEvent } from '../utils/validation.js';
+import { buildGitContext } from '../utils/git.js';
 
 // Import and register all built-in rules
 import '../rules/index.js';
@@ -42,8 +47,16 @@ export async function executeHook(event: HookEvent): Promise<void> {
       process.exit(0); // No config = no enforcement
     }
 
-    // 3. Extract tool info
+    // 3. Extract tool info + session identifier
     const { toolName } = extractToolInput(rawInput);
+    const sessionId = extractSessionId(rawInput);
+
+    // 3b. Session lifecycle events are short-circuited — no rules run,
+    // we just record a session marker and (optionally) kick off a flush.
+    if (event === 'SessionStart' || event === 'SessionEnd') {
+      handleSessionLifecycleEvent(event, sessionId, config.cloud);
+      process.exit(0);
+    }
 
     // 4. Build context
     const context = buildHookContext(
@@ -72,7 +85,7 @@ export async function executeHook(event: HookEvent): Promise<void> {
       | string
       | undefined;
     for (const ruleResult of result.results) {
-      recordRuleHit(ruleResult, event, toolName, filePath, process.cwd());
+      recordRuleHit(ruleResult, event, toolName, filePath, process.cwd(), sessionId);
     }
 
     // Record perf data
@@ -87,6 +100,9 @@ export async function executeHook(event: HookEvent): Promise<void> {
     if (config.cloud?.autoSync === true) {
       triggerRealTimeStream(process.cwd(), config.cloud);
       triggerConfigPush(process.cwd());
+      // Piggy-back a session-events flush on every hook — inexpensive
+      // safety net in case SessionEnd never fires (e.g. Claude Code crash).
+      triggerSessionEventFlush(process.cwd());
     }
 
     // 7b. Full flush on Stop events (catch any remaining buffered records)
@@ -178,4 +194,84 @@ function triggerCloudSync(projectRoot: string): void {
     .catch(() => {
       // Fail open — cloud sync errors should never impact the developer
     });
+}
+
+/**
+ * Handle a SessionStart or SessionEnd hook event.
+ *
+ * Records a session lifecycle marker to
+ * `.vguard/data/session-events.jsonl` (with branch/cli_version/cwd
+ * metadata on start) and fires a best-effort flush to the cloud
+ * sessions endpoint. No rules run on lifecycle events.
+ */
+function handleSessionLifecycleEvent(
+  event: 'SessionStart' | 'SessionEnd',
+  sessionId: string | undefined,
+  cloudConfig: CloudConfig | undefined,
+): void {
+  if (!sessionId) return; // Nothing we can correlate without a session id.
+
+  const projectRoot = process.cwd();
+
+  if (event === 'SessionStart') {
+    const gitContext = buildGitContext(projectRoot);
+    recordSessionEvent(
+      {
+        type: 'start',
+        sessionId,
+        branch: gitContext.branch ?? undefined,
+        cliVersion: readVguardVersion(projectRoot) ?? undefined,
+        agent: 'claude-code',
+        cwd: projectRoot,
+      },
+      projectRoot,
+    );
+  } else {
+    recordSessionEvent({ type: 'end', sessionId }, projectRoot);
+  }
+
+  // Kick off a background flush if cloud sync is enabled.
+  if (cloudConfig?.autoSync === true) {
+    triggerSessionEventFlush(projectRoot);
+  }
+}
+
+/**
+ * Non-blocking, fire-and-forget flush of pending session lifecycle events.
+ */
+function triggerSessionEventFlush(projectRoot: string): void {
+  void import('../cloud/credentials.js')
+    .then(({ readCredentials }) => {
+      const apiKey = process.env.VGUARD_API_KEY ?? readCredentials()?.apiKey;
+      if (!apiKey) return;
+      return import('../cloud/session-streamer.js').then(({ flushSessionEvents }) =>
+        flushSessionEvents(projectRoot, apiKey),
+      );
+    })
+    .catch(() => {
+      // Fail open — session telemetry must never impact the developer.
+    });
+}
+
+/**
+ * Best-effort read of the installed @solanticai/vguard package version,
+ * falling back to the consumer project's package.json during dev.
+ * Duplicated here (vs imported from config-pusher) to avoid a dependency
+ * cycle and to keep hook startup fast.
+ */
+function readVguardVersion(projectRoot: string): string | null {
+  const candidates = ['node_modules/@solanticai/vguard/package.json', 'package.json'];
+  for (const candidate of candidates) {
+    try {
+      const path = join(projectRoot, candidate);
+      if (!existsSync(path)) continue;
+      const pkg = JSON.parse(readFileSync(path, 'utf-8')) as { version?: string };
+      if (typeof pkg.version === 'string' && pkg.version.length > 0) {
+        return pkg.version;
+      }
+    } catch {
+      // Try next candidate
+    }
+  }
+  return null;
 }

--- a/src/engine/session-tracker.ts
+++ b/src/engine/session-tracker.ts
@@ -1,0 +1,73 @@
+/**
+ * Session lifecycle event tracker.
+ *
+ * Claude Code fires SessionStart when a session begins and SessionEnd
+ * when it terminates. We record these as JSONL lines so the cloud
+ * streamer can later upload them to /api/v1/sessions/events, which
+ * uses the events to stamp `started_at`, `ended_at`, and metadata
+ * (branch, cli_version, agent, cwd) onto the sessions table.
+ *
+ * This is a separate channel from rule hits — the cloud ingest endpoint
+ * is rule-hit-specific and blocks on session_id being optional.
+ */
+
+import { appendFileSync, existsSync, mkdirSync, renameSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+export type SessionEventType = 'start' | 'end';
+
+export interface SessionEventRecord {
+  type: SessionEventType;
+  sessionId: string;
+  timestamp: string;
+  branch?: string;
+  cliVersion?: string;
+  agent?: string;
+  cwd?: string;
+  metadata?: Record<string, unknown>;
+}
+
+const LOG_FILENAME = '.vguard/data/session-events.jsonl';
+const MAX_LOG_SIZE = 5 * 1024 * 1024; // 5MB (sessions are low-volume)
+
+/**
+ * Append a session lifecycle event to the JSONL log file.
+ * Fails open — tracking must never break normal hook operation.
+ */
+export function recordSessionEvent(
+  event: Omit<SessionEventRecord, 'timestamp'> & { timestamp?: string },
+  projectRoot: string,
+): void {
+  try {
+    const logPath = join(projectRoot, LOG_FILENAME);
+    const dir = dirname(logPath);
+
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+
+    if (existsSync(logPath)) {
+      const { size } = statSync(logPath);
+      if (size > MAX_LOG_SIZE) {
+        renameSync(logPath, logPath + '.old');
+      }
+    }
+
+    const record: SessionEventRecord = {
+      type: event.type,
+      sessionId: event.sessionId,
+      timestamp: event.timestamp ?? new Date().toISOString(),
+      ...(event.branch !== undefined ? { branch: event.branch } : {}),
+      ...(event.cliVersion !== undefined ? { cliVersion: event.cliVersion } : {}),
+      ...(event.agent !== undefined ? { agent: event.agent } : {}),
+      ...(event.cwd !== undefined ? { cwd: event.cwd } : {}),
+      ...(event.metadata !== undefined ? { metadata: event.metadata } : {}),
+    };
+
+    appendFileSync(logPath, JSON.stringify(record) + '\n', 'utf-8');
+  } catch {
+    // Fail open — lifecycle tracking must never interfere with normal operation.
+  }
+}
+
+export const SESSION_EVENTS_LOG = LOG_FILENAME;

--- a/src/engine/tracker.ts
+++ b/src/engine/tracker.ts
@@ -10,6 +10,8 @@ export interface RuleHitRecord {
   filePath?: string;
   event: HookEvent;
   tool: string;
+  /** Claude Code session identifier (forwarded from hook stdin) */
+  sessionId?: string;
 }
 
 const LOG_FILENAME = '.vguard/data/rule-hits.jsonl';
@@ -25,6 +27,7 @@ export function recordRuleHit(
   tool: string,
   filePath: string | undefined,
   projectRoot: string,
+  sessionId?: string,
 ): void {
   try {
     const logPath = join(projectRoot, LOG_FILENAME);
@@ -50,6 +53,7 @@ export function recordRuleHit(
       filePath,
       event,
       tool,
+      ...(sessionId !== undefined ? { sessionId } : {}),
     };
 
     appendFileSync(logPath, JSON.stringify(record) + '\n', 'utf-8');

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,8 @@ export interface HookContext {
   projectConfig: ResolvedConfig;
   /** Git repository context */
   gitContext: GitContext;
+  /** Claude Code session identifier (forwarded from the hook stdin payload) */
+  sessionId?: string;
 }
 
 // ─── Rule Result ────────────────────────────────────────────────────────────

--- a/src/utils/stdin.ts
+++ b/src/utils/stdin.ts
@@ -53,3 +53,19 @@ export function extractToolInput(data: Record<string, unknown>): {
   const toolInput = (data.tool_input as Record<string, unknown>) ?? {};
   return { toolName, toolInput };
 }
+
+/**
+ * Extract the Claude Code session identifier from a hook payload.
+ *
+ * Claude Code passes the active session's id as `session_id` in every
+ * hook stdin JSON payload. We forward it onto RuleHitRecord + session
+ * lifecycle events so the cloud dashboard can group rule hits by
+ * session and surface per-session drill-downs.
+ *
+ * Returns `undefined` when the caller didn't include a session id
+ * (e.g. another agent that doesn't support sessions, or malformed input).
+ */
+export function extractSessionId(data: Record<string, unknown>): string | undefined {
+  const sessionId = data.session_id;
+  return typeof sessionId === 'string' && sessionId.length > 0 ? sessionId : undefined;
+}

--- a/tests/adapters/claude-code.test.ts
+++ b/tests/adapters/claude-code.test.ts
@@ -79,6 +79,46 @@ describe('Claude Code adapter', () => {
     expect(commandNames).toContain('vguard-status');
     expect(commandNames).toContain('vguard-upgrade');
   });
+
+  it('should always generate SessionStart and SessionEnd hook scripts', async () => {
+    const files = await claudeCodeAdapter.generate(makeConfig(), '/project');
+    const hookPaths = files.filter((f) => f.path.startsWith('.vguard/hooks/')).map((f) => f.path);
+
+    expect(hookPaths).toContain('.vguard/hooks/vguard-sessionstart.js');
+    expect(hookPaths).toContain('.vguard/hooks/vguard-sessionend.js');
+  });
+
+  it('should register SessionStart and SessionEnd in settings.json without a matcher', async () => {
+    const files = await claudeCodeAdapter.generate(makeConfig(), '/project');
+    const settings = files.find((f) => f.path === '.claude/settings.json');
+    expect(settings).toBeDefined();
+
+    const parsed = JSON.parse(settings!.content) as {
+      hooks: Record<string, Array<Record<string, unknown>>>;
+    };
+
+    expect(parsed.hooks.SessionStart).toBeDefined();
+    expect(parsed.hooks.SessionEnd).toBeDefined();
+
+    // Lifecycle hooks are matcher-less
+    expect(parsed.hooks.SessionStart[0].matcher).toBeUndefined();
+    expect(parsed.hooks.SessionEnd[0].matcher).toBeUndefined();
+  });
+
+  it('should register SessionStart/SessionEnd even when no rules reference those events', async () => {
+    // Minimal config with rules that only target PreToolUse/PostToolUse/Stop
+    const config: ResolvedConfig = {
+      presets: [],
+      agents: ['claude-code'],
+      rules: new Map(),
+    };
+
+    const files = await claudeCodeAdapter.generate(config, '/project');
+    const hookPaths = files.filter((f) => f.path.startsWith('.vguard/hooks/')).map((f) => f.path);
+
+    expect(hookPaths).toContain('.vguard/hooks/vguard-sessionstart.js');
+    expect(hookPaths).toContain('.vguard/hooks/vguard-sessionend.js');
+  });
 });
 
 describe('Command generator', () => {

--- a/tests/engine/context.test.ts
+++ b/tests/engine/context.test.ts
@@ -129,4 +129,34 @@ describe('buildHookContext', () => {
       hasRemote: false,
     });
   });
+
+  it('forwards session_id onto HookContext.sessionId', () => {
+    const ctx = buildHookContext(
+      'PreToolUse',
+      {
+        tool_name: 'Edit',
+        tool_input: { file_path: '/project/src/index.ts' },
+        session_id: 'sess_xyz789',
+      },
+      config,
+    );
+
+    expect(ctx.sessionId).toBe('sess_xyz789');
+  });
+
+  it('omits sessionId when session_id is not provided', () => {
+    const ctx = buildHookContext('PreToolUse', { tool_name: 'Edit', tool_input: {} }, config);
+
+    expect(ctx.sessionId).toBeUndefined();
+  });
+
+  it('omits sessionId when session_id is an empty string', () => {
+    const ctx = buildHookContext(
+      'PreToolUse',
+      { tool_name: 'Edit', tool_input: {}, session_id: '' },
+      config,
+    );
+
+    expect(ctx.sessionId).toBeUndefined();
+  });
 });

--- a/tests/engine/session-tracker.test.ts
+++ b/tests/engine/session-tracker.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock fs to avoid real file operations (mirrors tracker.test.ts).
+const mockStore = new Map<string, string>();
+vi.mock('node:fs', async () => {
+  return {
+    existsSync: vi.fn((p: string) => mockStore.has(p)),
+    readFileSync: vi.fn((p: string) => {
+      const content = mockStore.get(p);
+      if (!content) throw new Error('ENOENT');
+      return content;
+    }),
+    appendFileSync: vi.fn((p: string, content: string) => {
+      const existing = mockStore.get(p) ?? '';
+      mockStore.set(p, existing + content);
+    }),
+    mkdirSync: vi.fn(),
+    statSync: vi.fn(() => ({ size: 100 })),
+    renameSync: vi.fn(),
+  };
+});
+
+const { recordSessionEvent } = await import('../../src/engine/session-tracker.js');
+
+function getEventsLog(): string[] {
+  for (const [key, content] of mockStore) {
+    if (key.includes('session-events.jsonl') && !key.endsWith('.old')) {
+      return content.trim().split('\n').filter(Boolean);
+    }
+  }
+  return [];
+}
+
+describe('engine/session-tracker', () => {
+  beforeEach(() => {
+    mockStore.clear();
+  });
+
+  it('records a SessionStart event with metadata', () => {
+    recordSessionEvent(
+      {
+        type: 'start',
+        sessionId: 'sess_abc123',
+        timestamp: '2026-04-05T12:00:00Z',
+        branch: 'main',
+        cliVersion: '1.6.0',
+        agent: 'claude-code',
+        cwd: '/project',
+      },
+      '/project',
+    );
+
+    const lines = getEventsLog();
+    expect(lines).toHaveLength(1);
+
+    const event = JSON.parse(lines[0]);
+    expect(event.type).toBe('start');
+    expect(event.sessionId).toBe('sess_abc123');
+    expect(event.timestamp).toBe('2026-04-05T12:00:00Z');
+    expect(event.branch).toBe('main');
+    expect(event.cliVersion).toBe('1.6.0');
+    expect(event.agent).toBe('claude-code');
+    expect(event.cwd).toBe('/project');
+  });
+
+  it('records a SessionEnd event with only the core fields', () => {
+    recordSessionEvent(
+      { type: 'end', sessionId: 'sess_abc123', timestamp: '2026-04-05T13:00:00Z' },
+      '/project',
+    );
+
+    const lines = getEventsLog();
+    expect(lines).toHaveLength(1);
+
+    const event = JSON.parse(lines[0]);
+    expect(event.type).toBe('end');
+    expect(event.sessionId).toBe('sess_abc123');
+    expect(event.timestamp).toBe('2026-04-05T13:00:00Z');
+    expect(event.branch).toBeUndefined();
+    expect(event.cliVersion).toBeUndefined();
+  });
+
+  it('omits optional fields when they are not provided', () => {
+    recordSessionEvent({ type: 'start', sessionId: 'sess_x' }, '/project');
+
+    const lines = getEventsLog();
+    const event = JSON.parse(lines[0]);
+    expect(event.type).toBe('start');
+    expect(event.sessionId).toBe('sess_x');
+    expect(event.branch).toBeUndefined();
+    expect(event.cliVersion).toBeUndefined();
+    expect(event.agent).toBeUndefined();
+    expect(event.cwd).toBeUndefined();
+    expect(event.metadata).toBeUndefined();
+    // But a timestamp is always added
+    expect(typeof event.timestamp).toBe('string');
+  });
+
+  it('appends multiple events to the same log', () => {
+    recordSessionEvent({ type: 'start', sessionId: 'sess_1' }, '/project');
+    recordSessionEvent({ type: 'end', sessionId: 'sess_1' }, '/project');
+
+    const lines = getEventsLog();
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]).type).toBe('start');
+    expect(JSON.parse(lines[1]).type).toBe('end');
+  });
+});

--- a/tests/engine/tracker.test.ts
+++ b/tests/engine/tracker.test.ts
@@ -78,4 +78,22 @@ describe('engine/tracker', () => {
     expect(hits.length).toBeGreaterThanOrEqual(1);
     expect(hits[0].ruleId).toBe('valid');
   });
+
+  it('should include sessionId when provided', () => {
+    const result: RuleResult = { status: 'pass', ruleId: 'security/branch-protection' };
+    recordRuleHit(result, 'PreToolUse', 'Edit', '/src/a.ts', '/project', 'sess_abc123');
+
+    const hits = readRuleHits('/project');
+    expect(hits).toHaveLength(1);
+    expect(hits[0].sessionId).toBe('sess_abc123');
+  });
+
+  it('should omit sessionId when not provided', () => {
+    const result: RuleResult = { status: 'pass', ruleId: 'rule' };
+    recordRuleHit(result, 'PreToolUse', 'Edit', '/src/a.ts', '/project');
+
+    const hits = readRuleHits('/project');
+    expect(hits).toHaveLength(1);
+    expect(hits[0].sessionId).toBeUndefined();
+  });
 });

--- a/tests/integration/hook-execution.test.ts
+++ b/tests/integration/hook-execution.test.ts
@@ -7,6 +7,7 @@ vi.mock('../../src/utils/stdin.js', () => ({
     toolName: (data.tool_name as string) ?? '',
     toolInput: (data.tool_input as Record<string, unknown>) ?? {},
   })),
+  extractSessionId: vi.fn((data: Record<string, unknown>) => data.session_id as string | undefined),
 }));
 
 vi.mock('../../src/config/compile.js', () => ({

--- a/tests/utils/stdin.test.ts
+++ b/tests/utils/stdin.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractToolInput } from '../../src/utils/stdin.js';
+import { extractToolInput, extractSessionId } from '../../src/utils/stdin.js';
 
 describe('extractToolInput', () => {
   it('extracts tool_name and tool_input', () => {
@@ -30,6 +30,33 @@ describe('extractToolInput', () => {
     const result = extractToolInput({ unrelated: true });
     expect(result.toolName).toBe('');
     expect(result.toolInput).toEqual({});
+  });
+});
+
+describe('extractSessionId', () => {
+  it('extracts session_id when present', () => {
+    const result = extractSessionId({ session_id: 'sess_abc123', tool_name: 'Edit' });
+    expect(result).toBe('sess_abc123');
+  });
+
+  it('returns undefined when session_id is missing', () => {
+    const result = extractSessionId({ tool_name: 'Edit' });
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when session_id is empty string', () => {
+    const result = extractSessionId({ session_id: '', tool_name: 'Edit' });
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when session_id is a non-string', () => {
+    const result = extractSessionId({ session_id: 123 as unknown as string });
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when session_id is null', () => {
+    const result = extractSessionId({ session_id: null as unknown as string });
+    expect(result).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Claude Code passes a \`session_id\` with every hook invocation, but the CLI has been silently discarding it since the beginning. Every \`rule_hits.session_id\` in the cloud dashboard was null, so sessions couldn't be grouped, filtered, or drilled into. This PR captures session_id and ships \`SessionStart\`/\`SessionEnd\` lifecycle hooks so sessions materialise as first-class objects on the cloud dashboard.

**This is step 2** of the cross-repo session-tracking rollout. The server-side migrations, \`/api/v1/sessions/events\` endpoint, and dashboard UI ship in **vibe-guard-cloud PR #9** — which should deploy first.

**Version:** 1.4.1 → **1.6.0** (new feature → minor bump). Assumes PR #15 (v1.5.0) merges first; rebase if needed.

## What changed

### Core data flow

| File | Change |
|---|---|
| \`src/utils/stdin.ts\` | New \`extractSessionId()\` — reads and validates \`session_id\` from hook stdin payload |
| \`src/engine/context.ts\` | \`buildHookContext\` threads session_id from \`RawHookInput\` onto \`HookContext.sessionId\` |
| \`src/types.ts\` | \`HookContext\` gains optional \`sessionId\` field |
| \`src/engine/tracker.ts\` | \`RuleHitRecord.sessionId\` + 6th optional \`sessionId\` param on \`recordRuleHit()\` |
| \`src/engine/hook-entry.ts\` | Extracts session_id from stdin, passes to tracker, handles lifecycle events |

### Session lifecycle

| File | Change |
|---|---|
| \`src/adapters/claude-code/adapter.ts\` | Always registers \`SessionStart\` + \`SessionEnd\` hooks (no matcher, fires even with no active rules) |
| \`src/engine/session-tracker.ts\` (new) | Append-only JSONL tracker for session-start/session-end markers |
| \`src/cloud/session-streamer.ts\` (new) | Cursor-based flush of pending session events to \`/api/v1/sessions/events\` |
| \`src/cloud/client.ts\` | New \`postSessionEvents()\` method |

### Tests

- **extractSessionId**: present / missing / empty / non-string / null (5 cases)
- **buildHookContext**: session_id threaded / missing / empty (3 cases)
- **recordRuleHit**: sessionId present / absent (2 cases)
- **session-tracker**: start with metadata / end / missing optional fields / multiple events (4 cases)
- **claude-code adapter**: SessionStart+End scripts generated, matcher-less, always registered even without rules (3 cases)
- **hook-execution integration**: mocks updated to include \`extractSessionId\`

**Suite: 694 → 711 tests, all passing.**

## Test Plan

- [x] \`npm run lint\` clean
- [x] \`npm run type-check\` clean
- [x] \`npm run format:check\` clean
- [x] \`npm test\` — 711 passing
- [x] \`npm run build\` — ESM + CJS clean
- [ ] E2E (post-merge on staging): run \`vguard init\` + \`vguard generate\` on a test repo, verify \`.vguard/data/rule-hits.jsonl\` carries \`sessionId\`, verify \`.vguard/data/session-events.jsonl\` carries start/end records, verify cloud \`sessions\` table populates.

## Deployment coordination

1. **vibe-guard-cloud PR #9** merges + deploys first (migrations + API + UI). Backward compatible.
2. **This PR** merges to \`dev\`, then release PR to \`master\`, then npm publish \`@solanticai/vguard@1.6.0\`.
3. Users run \`vguard generate\` to refresh \`.claude/settings.json\` with the new lifecycle hooks. (New projects pick them up automatically on \`vguard init\`.)

## Out of scope

- Historical \`rule_hits\` with null \`session_id\` stay null (new rows populate going forward).
- Non-Claude-Code agents (Cursor/Codex/OpenCode) — they don't support runtime hooks, so session tracking doesn't apply.