### PR TITLE
feat(ignore): add .vguardignore for project-wide file exclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-04-05
+
+### Added
+
+- **`.vguardignore` file support.** VGuard now reads a project-level
+  `.vguardignore` (gitignore syntax) that excludes files and folders
+  from every VGuard execution path — `vguard lint`, Claude Code
+  runtime hooks (PreToolUse / PostToolUse), and `vguard learn`. This
+  solves the common complaint that auto-generated UI libraries
+  (shadcn/ui) and frozen SQL migrations were surfacing false-positive
+  violations that had no clean project-wide opt-out.
+- **`vguard init` creates a starter `.vguardignore`** with active
+  defaults (generated-code globs, IDE/OS cruft) plus commented hints
+  for common opt-ins (`src/components/ui/`, `supabase/migrations/`,
+  `prisma/migrations/`, snapshot/fixture folders). Existing
+  `.vguardignore` files are never overwritten.
+- **New `vguard ignore` subcommand** for managing the file without
+  opening it: `vguard ignore list` prints active patterns grouped by
+  source (defaults vs file), `vguard ignore add <pattern>` / `remove
+<pattern>` edit the file safely (dedupes, preserves comments),
+  `vguard ignore check <path>` reports whether a path is ignored and
+  which pattern matched, and `vguard ignore init` standalone-creates
+  the file for projects that predate v1.7.0.
+- **`vguard doctor` new check** reports `.vguardignore` status and
+  active pattern count, and warns when legacy `learn.ignorePaths` or
+  `cloud.excludePaths` config fields are set (with guidance to move
+  them into `.vguardignore`).
+
+### Changed
+
+- `vguard learn` now merges `.vguardignore` with its existing
+  `learn.ignorePaths` config field — they compose, so users don't
+  have to choose. Same pattern for `cloud.excludePaths` in the sync /
+  streamer privacy filter.
+- `vguard generate` now clears the ignore-matcher cache so edits to
+  `.vguardignore` propagate to the next hook / lint run without
+  needing to restart the process.
+- Added `ignore@^7.0.5` as a runtime dependency. This is the same
+  ~8KB MIT package used by ESLint, Prettier, and stylelint for full
+  gitignore semantics (negation with `!`, directory suffixes, globs,
+  comments, nested patterns).
+
+### Deprecated
+
+- `learn.ignorePaths` and `cloud.excludePaths` config fields — both
+  still work unchanged but are bridged into the new `IgnoreMatcher`.
+  `vguard doctor` surfaces a deprecation hint when either is set.
+  Plan to remove in v2.0.
+
 ## [1.4.1] - 2026-04-05
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@solanticai/vguard",
-  "version": "1.0.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solanticai/vguard",
-      "version": "1.0.0",
+      "version": "1.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^14.0.3",
+        "ignore": "^7.0.5",
         "inquirer": "^13.3.2",
         "jiti": "^2.6.1",
         "zod": "^4.3.6"
@@ -2190,16 +2191,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.58.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
@@ -3199,6 +3190,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/eslint/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -3554,10 +3555,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "license": "MIT",
       "engines": {
         "node": ">= 4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solanticai/vguard",
-  "version": "1.4.1",
+  "version": "1.7.0",
   "description": "AI coding guardrails framework. Runtime-enforced quality controls for Claude Code, Cursor, Codex, and more.",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -66,6 +66,7 @@
   },
   "dependencies": {
     "commander": "^14.0.3",
+    "ignore": "^7.0.5",
     "inquirer": "^13.3.2",
     "jiti": "^2.6.1",
     "zod": "^4.3.6"

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -9,6 +9,7 @@ import { resolveConfig } from '../../config/loader.js';
 import { getAllPresets } from '../../config/presets.js';
 import { getAllRules } from '../../engine/registry.js';
 import { readPerfEntries, calculatePerfStats, PERF_BUDGET_MS } from '../../engine/perf.js';
+import { createIgnoreMatcher, HARDCODED_DEFAULTS } from '../../utils/ignore.js';
 import type { VGuardConfig } from '../../types.js';
 
 interface CheckResult {
@@ -42,10 +43,11 @@ export async function doctorCommand(): Promise<void> {
 
   // 2. Validate config
   let resolvedConfig;
+  let rawConfig: VGuardConfig;
   try {
-    const rawConfig = await readRawConfig(discovered);
+    rawConfig = (await readRawConfig(discovered)) as VGuardConfig;
     const presetMap = getAllPresets();
-    resolvedConfig = resolveConfig(rawConfig as VGuardConfig, presetMap);
+    resolvedConfig = resolveConfig(rawConfig, presetMap);
     results.push({
       name: 'Config valid',
       status: 'pass',
@@ -168,6 +170,41 @@ export async function doctorCommand(): Promise<void> {
       name: 'node_modules',
       status: 'warn',
       message: 'VGuard not found in node_modules. Hook scripts may not work. Run `npm install`.',
+    });
+  }
+
+  // 9. Check .vguardignore + legacy ignore-field deprecations.
+  const matcher = createIgnoreMatcher(projectRoot);
+  if (matcher.hasFile) {
+    results.push({
+      name: 'Ignore rules',
+      status: 'pass',
+      message: `${matcher.filePatterns.length} patterns from .vguardignore + ${HARDCODED_DEFAULTS.length} defaults active`,
+    });
+  } else {
+    results.push({
+      name: 'Ignore rules',
+      status: 'warn',
+      message:
+        'No .vguardignore found — using defaults only. Run `vguard ignore init` to add project-specific excludes.',
+    });
+  }
+
+  const learnIgnore = (rawConfig.learn?.ignorePaths ?? []).length;
+  if (learnIgnore > 0) {
+    results.push({
+      name: 'Legacy config',
+      status: 'warn',
+      message: `learn.ignorePaths is deprecated (${learnIgnore} entries) — move them to .vguardignore so they apply to lint + hooks too.`,
+    });
+  }
+
+  const cloudExclude = (resolvedConfig.cloud?.excludePaths ?? []).length;
+  if (cloudExclude > 0) {
+    results.push({
+      name: 'Legacy config',
+      status: 'warn',
+      message: `cloud.excludePaths is deprecated (${cloudExclude} entries) — move them to .vguardignore for project-wide exclusion.`,
     });
   }
 

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -15,12 +15,17 @@ import { codexAdapter } from '../../adapters/codex/adapter.js';
 import { openCodeAdapter } from '../../adapters/opencode/adapter.js';
 import { githubActionsAdapter } from '../../adapters/github-actions/adapter.js';
 import { mergeSettings } from '../../adapters/claude-code/settings-merger.js';
+import { clearIgnoreMatcherCache } from '../../utils/ignore.js';
 import type { VGuardConfig, GeneratedFile } from '../../types.js';
 
 export async function generateCommand(): Promise<void> {
   const projectRoot = process.cwd();
 
   console.log('\n  VGuard — Regenerating hooks...\n');
+
+  // Drop the ignore-matcher cache so the next lint/hook run re-reads
+  // any edits the user made to .vguardignore.
+  clearIgnoreMatcherCache();
 
   // Load config
   const discovered = discoverConfigFile(projectRoot);

--- a/src/cli/commands/ignore.ts
+++ b/src/cli/commands/ignore.ts
@@ -1,0 +1,228 @@
+/**
+ * `vguard ignore` — manage the project's .vguardignore file without
+ * opening it in an editor.
+ *
+ * Subcommands:
+ *   list               print active patterns grouped by source
+ *   add <pattern>      append a pattern
+ *   remove <pattern>   remove an exact pattern line
+ *   check <path>       report whether a path is ignored
+ *   init               create a .vguardignore with the default template
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import ignorePkg from 'ignore';
+
+import {
+  createIgnoreMatcher,
+  clearIgnoreMatcherCache,
+  HARDCODED_DEFAULTS,
+  VGUARD_IGNORE_FILENAME,
+} from '../../utils/ignore.js';
+import { normalizePath } from '../../utils/path.js';
+import { isAbsolute, relative, resolve } from 'node:path';
+import { DEFAULT_VGUARDIGNORE } from './init-templates/vguardignore.js';
+
+function ignorePath(projectRoot: string): string {
+  return join(projectRoot, VGUARD_IGNORE_FILENAME);
+}
+
+/**
+ * Read raw `.vguardignore` content with line endings preserved.
+ * Returns `null` if the file doesn't exist.
+ */
+function readRaw(projectRoot: string): string | null {
+  const path = ignorePath(projectRoot);
+  if (!existsSync(path)) return null;
+  try {
+    return readFileSync(path, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+async function writeRaw(projectRoot: string, content: string): Promise<void> {
+  await writeFile(ignorePath(projectRoot), content, 'utf-8');
+}
+
+/**
+ * Print every active ignore pattern grouped by source.
+ */
+export function ignoreListCommand(): void {
+  const projectRoot = process.cwd();
+  const matcher = createIgnoreMatcher(projectRoot);
+
+  console.log('\n  VGuard ignore patterns\n');
+
+  console.log('  [default]  (always-on, built-in)');
+  for (const pattern of HARDCODED_DEFAULTS) {
+    console.log(`    ${pattern}`);
+  }
+
+  if (matcher.hasFile) {
+    console.log(`\n  [${VGUARD_IGNORE_FILENAME}]  ${matcher.filePatterns.length} pattern(s)`);
+    if (matcher.filePatterns.length === 0) {
+      console.log('    (no non-comment patterns)');
+    } else {
+      for (const pattern of matcher.filePatterns) {
+        console.log(`    ${pattern}`);
+      }
+    }
+  } else {
+    console.log(
+      `\n  [${VGUARD_IGNORE_FILENAME}]  (not found) — run \`vguard ignore init\` to create one`,
+    );
+  }
+
+  const total = HARDCODED_DEFAULTS.length + matcher.filePatterns.length;
+  console.log(`\n  ${total} pattern(s) total\n`);
+}
+
+/**
+ * Append a pattern to `.vguardignore`. Creates the file if missing.
+ * Refuses to add duplicate patterns.
+ */
+export async function ignoreAddCommand(pattern: string): Promise<void> {
+  const trimmed = pattern.trim();
+  if (!trimmed) {
+    console.error('  Pattern cannot be empty.');
+    process.exit(1);
+  }
+  if (trimmed.startsWith('#')) {
+    console.error('  Refusing to add a comment as a pattern.');
+    process.exit(1);
+  }
+
+  const projectRoot = process.cwd();
+  const existing = readRaw(projectRoot);
+
+  let content: string;
+  if (existing === null) {
+    // Create from template + the new pattern at the end.
+    content = DEFAULT_VGUARDIGNORE.trimEnd() + '\n\n' + trimmed + '\n';
+    console.log(`  Created ${VGUARD_IGNORE_FILENAME} with "${trimmed}".`);
+  } else {
+    // Duplicate check against non-comment lines.
+    const lines = existing.split(/\r?\n/);
+    const alreadyPresent = lines.map((l) => l.trim()).some((l) => l === trimmed);
+    if (alreadyPresent) {
+      console.log(`  "${trimmed}" is already in ${VGUARD_IGNORE_FILENAME}.`);
+      return;
+    }
+    const needsNewline = !existing.endsWith('\n');
+    content = existing + (needsNewline ? '\n' : '') + trimmed + '\n';
+    console.log(`  Added "${trimmed}" to ${VGUARD_IGNORE_FILENAME}.`);
+  }
+
+  await writeRaw(projectRoot, content);
+  clearIgnoreMatcherCache();
+}
+
+/**
+ * Remove the first exact-match line from `.vguardignore`. Comments and
+ * blank lines are preserved.
+ */
+export async function ignoreRemoveCommand(pattern: string): Promise<void> {
+  const trimmed = pattern.trim();
+  if (!trimmed) {
+    console.error('  Pattern cannot be empty.');
+    process.exit(1);
+  }
+
+  const projectRoot = process.cwd();
+  const existing = readRaw(projectRoot);
+  if (existing === null) {
+    console.log(`  No ${VGUARD_IGNORE_FILENAME} found — nothing to remove.`);
+    return;
+  }
+
+  const lines = existing.split(/\r?\n/);
+  let removed = 0;
+  const next = lines.filter((line) => {
+    if (line.trim() === trimmed) {
+      removed++;
+      return false;
+    }
+    return true;
+  });
+
+  if (removed === 0) {
+    console.log(`  "${trimmed}" is not in ${VGUARD_IGNORE_FILENAME}.`);
+    return;
+  }
+
+  await writeRaw(projectRoot, next.join('\n'));
+  clearIgnoreMatcherCache();
+  console.log(`  Removed "${trimmed}" from ${VGUARD_IGNORE_FILENAME}.`);
+}
+
+/**
+ * Report whether a given path is ignored, and by which pattern source.
+ */
+export function ignoreCheckCommand(path: string): void {
+  if (!path) {
+    console.error('  Usage: vguard ignore check <path>');
+    process.exit(1);
+  }
+  const projectRoot = process.cwd();
+  const matcher = createIgnoreMatcher(projectRoot);
+  const isIgnored = matcher.isIgnored(path);
+
+  if (!isIgnored) {
+    console.log(`  included ${path}`);
+    console.log('           (no pattern matched)');
+    return;
+  }
+
+  console.log(`  ignored  ${path}`);
+
+  // Test each bucket separately to tell the user WHICH source matched.
+  const rel = toRelativeForIgnore(projectRoot, path);
+  if (!rel) {
+    console.log('           (matched)');
+    return;
+  }
+
+  const defaultsIg = ignorePkg().add([...HARDCODED_DEFAULTS]);
+  if (defaultsIg.ignores(rel)) {
+    console.log('           (matched by built-in default)');
+    return;
+  }
+
+  if (matcher.filePatterns.length > 0) {
+    const fileIg = ignorePkg().add(matcher.filePatterns);
+    if (fileIg.ignores(rel)) {
+      console.log(`           (matched by ${VGUARD_IGNORE_FILENAME})`);
+      return;
+    }
+  }
+
+  console.log('           (matched by a passed-in extra pattern)');
+}
+
+function toRelativeForIgnore(projectRoot: string, filePath: string): string {
+  const normalised = normalizePath(filePath);
+  if (isAbsolute(filePath)) {
+    return normalizePath(relative(resolve(projectRoot), filePath));
+  }
+  return normalised.replace(/^\.\//, '');
+}
+
+/**
+ * Create a `.vguardignore` with the default template.
+ * No-op (and reports "already exists") if the file is present.
+ */
+export async function ignoreInitCommand(): Promise<void> {
+  const projectRoot = process.cwd();
+  const path = ignorePath(projectRoot);
+  if (existsSync(path)) {
+    console.log(`  ${VGUARD_IGNORE_FILENAME} already exists — leaving it untouched.`);
+    return;
+  }
+  await writeRaw(projectRoot, DEFAULT_VGUARDIGNORE);
+  clearIgnoreMatcherCache();
+  console.log(`  Created ${VGUARD_IGNORE_FILENAME}`);
+}

--- a/src/cli/commands/init-templates/vguardignore.ts
+++ b/src/cli/commands/init-templates/vguardignore.ts
@@ -1,0 +1,51 @@
+/**
+ * Default `.vguardignore` content created by `vguard init` and
+ * `vguard ignore init`.
+ *
+ * Starts with a header + commented hints so users immediately
+ * understand what the file is and what they can add to it.
+ */
+
+export const DEFAULT_VGUARDIGNORE = `# VGuard ignore — files and folders listed here are excluded from
+# all vguard rules, hooks, and scans (vguard lint, runtime hooks,
+# and vguard learn).
+#
+# Syntax mirrors .gitignore (https://git-scm.com/docs/gitignore):
+#   node_modules/                 ignores everything in node_modules/
+#   *.generated.ts                ignores all .generated.ts files anywhere
+#   src/components/ui/**          ignores a specific directory tree
+#   !src/components/ui/button.tsx re-includes a file
+#
+# These patterns are ADDITIVE on top of the built-in defaults
+# (node_modules/, .next/, dist/, build/, .git/, coverage/, .vguard/,
+# .turbo/, __pycache__/, .venv/). You do not need to re-list them.
+#
+# Tip: if you have patterns in your .gitignore you'd also like vguard
+# to respect, copy the relevant lines here.
+
+# Generated code
+**/*.generated.ts
+**/*.generated.js
+**/*.min.js
+
+# Type declaration files (emitted, not hand-written)
+**/*.d.ts
+
+# IDE / OS
+.vscode/
+.idea/
+.DS_Store
+
+# Common third-party / generated UI directories (uncomment if used)
+# src/components/ui/
+# packages/ui/
+
+# Frozen SQL migrations (uncomment if your migrations are append-only)
+# supabase/migrations/
+# prisma/migrations/
+# migrations/
+
+# Fixtures / snapshots
+# **/__snapshots__/
+# **/fixtures/
+`;

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -17,6 +17,7 @@ import { codexAdapter } from '../../adapters/codex/adapter.js';
 import { openCodeAdapter } from '../../adapters/opencode/adapter.js';
 import { githubActionsAdapter } from '../../adapters/github-actions/adapter.js';
 import { mergeSettings } from '../../adapters/claude-code/settings-merger.js';
+import { DEFAULT_VGUARDIGNORE } from './init-templates/vguardignore.js';
 
 export async function initCommand(): Promise<void> {
   const projectRoot = process.cwd();
@@ -222,6 +223,15 @@ export default defineConfig(${JSON.stringify(config, null, 2)});
   if (selectedFolders.has('github-actions')) {
     const gaFiles = await githubActionsAdapter.generate(resolvedConfig, projectRoot);
     for (const file of gaFiles) await writeGeneratedFile(file);
+  }
+
+  // Write starter .vguardignore (create-only — don't overwrite existing).
+  const ignorePath = join(projectRoot, '.vguardignore');
+  if (!existsSync(ignorePath)) {
+    await writeFile(ignorePath, DEFAULT_VGUARDIGNORE, 'utf-8');
+    console.log('  Created .vguardignore');
+  } else {
+    console.log('  Skipped .vguardignore (already exists)');
   }
 
   // Offer to add convenience npm scripts

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -180,4 +180,49 @@ program
     await syncCommand(options);
   });
 
+// Ignore subcommands (.vguardignore management)
+const ignore = program
+  .command('ignore')
+  .description('Manage .vguardignore (exclude files from rules, hooks, and scans)');
+
+ignore
+  .command('list')
+  .description('List all active ignore patterns, grouped by source')
+  .action(async () => {
+    const { ignoreListCommand } = await import('./commands/ignore.js');
+    ignoreListCommand();
+  });
+
+ignore
+  .command('add <pattern>')
+  .description('Append a pattern to .vguardignore (creates it if missing)')
+  .action(async (pattern: string) => {
+    const { ignoreAddCommand } = await import('./commands/ignore.js');
+    await ignoreAddCommand(pattern);
+  });
+
+ignore
+  .command('remove <pattern>')
+  .description('Remove an exact pattern from .vguardignore')
+  .action(async (pattern: string) => {
+    const { ignoreRemoveCommand } = await import('./commands/ignore.js');
+    await ignoreRemoveCommand(pattern);
+  });
+
+ignore
+  .command('check <path>')
+  .description('Print whether a path is ignored and which source matched')
+  .action(async (path: string) => {
+    const { ignoreCheckCommand } = await import('./commands/ignore.js');
+    ignoreCheckCommand(path);
+  });
+
+ignore
+  .command('init')
+  .description('Create a .vguardignore with the default template')
+  .action(async () => {
+    const { ignoreInitCommand } = await import('./commands/ignore.js');
+    await ignoreInitCommand();
+  });
+
 program.parse();

--- a/src/cloud/streamer.ts
+++ b/src/cloud/streamer.ts
@@ -144,10 +144,8 @@ export async function maybeFlushToCloud(
       return;
     }
 
-    // Apply path exclusions
-    if (cloudConfig.excludePaths && cloudConfig.excludePaths.length > 0) {
-      unsyncedRecords = applyExclusions(unsyncedRecords, cloudConfig.excludePaths);
-    }
+    // Apply path exclusions (.vguardignore + cloud.excludePaths)
+    unsyncedRecords = applyExclusions(unsyncedRecords, projectRoot, cloudConfig.excludePaths ?? []);
 
     // Limit batch size to avoid large payloads during streaming
     const maxStreamBatch = Math.min(unsyncedRecords.length, 50);

--- a/src/cloud/sync.ts
+++ b/src/cloud/sync.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { readRuleHits, type RuleHitRecord } from '../engine/tracker.js';
 import { CloudClient } from './client.js';
+import { createIgnoreMatcher } from '../utils/ignore.js';
 
 const CURSOR_FILE = '.vguard/data/sync-cursor.json';
 
@@ -51,29 +52,33 @@ export function getUnsyncedRecords(
 }
 
 /**
- * Apply excludePaths patterns to strip file paths from records.
+ * Strip `filePath` from any record whose path matches `.vguardignore` or
+ * the `cloud.excludePaths` config (merged via IgnoreMatcher extras).
+ *
+ * This is a PRIVACY filter — it only nulls out the `filePath` field
+ * before upload. Rules still run on these files; we simply don't send
+ * the path to the cloud.
+ *
+ * `projectRoot` is required so paths can be normalised relative to it
+ * and so `.vguardignore` is honoured the same way it is everywhere else.
  */
-export function applyExclusions(records: RuleHitRecord[], excludePaths: string[]): RuleHitRecord[] {
-  if (excludePaths.length === 0) return records;
+export function applyExclusions(
+  records: RuleHitRecord[],
+  projectRoot: string,
+  excludePaths: readonly string[] = [],
+): RuleHitRecord[] {
+  // Empty defaults + empty extras is the common case: no matcher needed.
+  if (excludePaths.length === 0) {
+    // Still run through .vguardignore if one exists.
+    const defaultMatcher = createIgnoreMatcher(projectRoot);
+    if (!defaultMatcher.hasFile) return records;
+  }
+
+  const matcher = createIgnoreMatcher(projectRoot, excludePaths);
 
   return records.map((record) => {
     if (!record.filePath) return record;
-
-    const shouldExclude = excludePaths.some((pattern) => {
-      if (pattern === '**/*') return true;
-      // Simple glob matching for common patterns
-      const normalized = pattern.replace(/\\/g, '/').replace(/\*\*/g, '').replace(/\/\//g, '/');
-      const filePath = record.filePath?.replace(/\\/g, '/') ?? '';
-      // Match if the file path contains the pattern's non-glob segments
-      const segments = normalized.split('/').filter(Boolean);
-      return segments.every((seg) => {
-        if (seg === '*') return true;
-        if (seg.startsWith('*.')) return filePath.includes(seg.slice(1)); // *.env → .env
-        return filePath.includes(seg);
-      });
-    });
-
-    if (shouldExclude) {
+    if (matcher.isIgnored(record.filePath)) {
       return { ...record, filePath: undefined };
     }
     return record;
@@ -113,10 +118,8 @@ export async function syncToCloud(
       return { synced: 0, skipped: 0 };
     }
 
-    // Apply path exclusions
-    if (options.excludePaths && options.excludePaths.length > 0) {
-      unsyncedRecords = applyExclusions(unsyncedRecords, options.excludePaths);
-    }
+    // Apply path exclusions (matches both .vguardignore + cloud.excludePaths)
+    unsyncedRecords = applyExclusions(unsyncedRecords, projectRoot, options.excludePaths ?? []);
 
     if (options.dryRun) {
       return { synced: 0, skipped: unsyncedRecords.length };

--- a/src/engine/hook-entry.ts
+++ b/src/engine/hook-entry.ts
@@ -15,6 +15,7 @@ import { recordRuleHit } from './tracker.js';
 import { recordPerfEntry } from './perf.js';
 import { formatPreToolUseOutput, formatPostToolUseOutput, formatStopOutput } from './output.js';
 import { isValidHookEvent } from '../utils/validation.js';
+import { createIgnoreMatcher } from '../utils/ignore.js';
 
 // Import and register all built-in rules
 import '../rules/index.js';
@@ -44,6 +45,18 @@ export async function executeHook(event: HookEvent): Promise<void> {
 
     // 3. Extract tool info
     const { toolName } = extractToolInput(rawInput);
+
+    // 3b. Honour .vguardignore — if the file being touched matches an
+    // ignore pattern, short-circuit BEFORE running rules, recording hits,
+    // or doing any cloud work. This keeps shadcn edits, migrations, etc.
+    // from triggering blocks/warns at edit time.
+    const ignoredFilePath = (rawInput.tool_input as { file_path?: string } | undefined)?.file_path;
+    if (ignoredFilePath) {
+      const matcher = createIgnoreMatcher(process.cwd());
+      if (matcher.isIgnored(ignoredFilePath)) {
+        process.exit(0);
+      }
+    }
 
     // 4. Build context
     const context = buildHookContext(

--- a/src/engine/scanner.ts
+++ b/src/engine/scanner.ts
@@ -4,6 +4,7 @@ import type { Rule, HookContext, ResolvedConfig } from '../types.js';
 import { getAllRules } from './registry.js';
 import { normalizePath, getExtension, matchesPattern } from '../utils/path.js';
 import { buildGitContext } from '../utils/git.js';
+import { createIgnoreMatcher, type IgnoreMatcher } from '../utils/ignore.js';
 
 /** A single issue found during scanning */
 export interface ScanIssue {
@@ -26,19 +27,12 @@ export interface ScanOptions {
   rootDir: string;
   config: ResolvedConfig;
   include?: string[];
-  exclude?: string[];
+  /**
+   * Optional ignore matcher override (primarily for tests). When absent, a
+   * matcher is created from `.vguardignore` + built-in defaults at `rootDir`.
+   */
+  ignoreMatcher?: IgnoreMatcher;
 }
-
-const DEFAULT_EXCLUDE = [
-  'node_modules/',
-  '.next/',
-  'dist/',
-  'build/',
-  '.git/',
-  'coverage/',
-  '.vguard/',
-  '__pycache__/',
-];
 
 const SCANNABLE_EXTENSIONS = new Set([
   'ts',
@@ -59,7 +53,8 @@ const SCANNABLE_EXTENSIONS = new Set([
  * This is the engine behind `vguard lint`.
  */
 export async function scanProject(options: ScanOptions): Promise<ScanResult> {
-  const { rootDir, config, exclude = DEFAULT_EXCLUDE } = options;
+  const { rootDir, config } = options;
+  const ignoreMatcher = options.ignoreMatcher ?? createIgnoreMatcher(rootDir);
 
   const allRules = getAllRules();
   const gitContext = buildGitContext(rootDir);
@@ -84,7 +79,7 @@ export async function scanProject(options: ScanOptions): Promise<ScanResult> {
   }
 
   // Walk the directory
-  const files = walkDirectory(rootDir, exclude);
+  const files = walkDirectory(rootDir, ignoreMatcher);
   const issues: ScanIssue[] = [];
 
   for (const filePath of files) {
@@ -145,8 +140,13 @@ export async function scanProject(options: ScanOptions): Promise<ScanResult> {
   };
 }
 
-/** Recursively walk a directory, respecting exclude patterns */
-function walkDirectory(dir: string, exclude: string[]): string[] {
+/**
+ * Recursively walk a directory, skipping any paths that the IgnoreMatcher
+ * says to ignore. Ignored directories are short-circuited (their contents
+ * are never read), so the scanner doesn't walk into node_modules/, .next/,
+ * etc.
+ */
+function walkDirectory(dir: string, matcher: IgnoreMatcher): string[] {
   const files: string[] = [];
 
   try {
@@ -154,21 +154,14 @@ function walkDirectory(dir: string, exclude: string[]): string[] {
     for (const entry of entries) {
       const fullPath = join(dir, entry);
 
-      // Check exclude — match against directory/file name segments, not substrings
-      const entryLower = entry.toLowerCase();
-      const isExcluded = exclude.some((pattern) => {
-        const cleanPattern = pattern.replace(/\/$/, '').toLowerCase();
-        // Match exact directory/file name to avoid false positives
-        // (e.g., exclude "node_modules" should not exclude "node-utils")
-        return entryLower === cleanPattern;
-      });
-      if (isExcluded) continue;
-
       try {
         const stat = statSync(fullPath);
         if (stat.isDirectory()) {
-          files.push(...walkDirectory(fullPath, exclude));
+          // Probe with a trailing slash so directory-only patterns match.
+          if (matcher.isIgnored(fullPath + '/')) continue;
+          files.push(...walkDirectory(fullPath, matcher));
         } else if (stat.isFile()) {
+          if (matcher.isIgnored(fullPath)) continue;
           files.push(fullPath);
         }
       } catch {

--- a/src/learn/walker.ts
+++ b/src/learn/walker.ts
@@ -1,20 +1,7 @@
 import { readdirSync, statSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { normalizePath } from '../utils/path.js';
-
-const DEFAULT_EXCLUDE = [
-  'node_modules',
-  '.next',
-  'dist',
-  'build',
-  '.git',
-  'coverage',
-  '.vguard',
-  '__pycache__',
-  '.venv',
-  'vendor',
-  '.turbo',
-];
+import { createIgnoreMatcher, type IgnoreMatcher } from '../utils/ignore.js';
 
 const ANALYZABLE_EXTENSIONS = new Set([
   'ts',
@@ -41,6 +28,11 @@ export interface WalkedFile {
 export interface WalkOptions {
   rootDir: string;
   scanPaths?: string[];
+  /**
+   * Legacy per-walk ignore patterns (from `config.learn.ignorePaths`).
+   * These are merged on top of `.vguardignore` + hardcoded defaults.
+   * Prefer `.vguardignore` for new projects — see `vguard ignore`.
+   */
   ignorePaths?: string[];
   maxFiles?: number;
 }
@@ -49,19 +41,20 @@ export interface WalkOptions {
  * Walk a project directory and return analyzable source files.
  */
 export function walkProject(options: WalkOptions): WalkedFile[] {
-  const { rootDir, ignorePaths = DEFAULT_EXCLUDE, maxFiles = 5000 } = options;
+  const { rootDir, ignorePaths = [], maxFiles = 5000 } = options;
+  const matcher = createIgnoreMatcher(rootDir, ignorePaths);
   const files: WalkedFile[] = [];
   const scanDirs = options.scanPaths?.map((p) => join(rootDir, p)) ?? [rootDir];
 
   for (const dir of scanDirs) {
-    walkDir(dir, ignorePaths, files, maxFiles);
+    walkDir(dir, matcher, files, maxFiles);
     if (files.length >= maxFiles) break;
   }
 
   return files;
 }
 
-function walkDir(dir: string, exclude: string[], files: WalkedFile[], maxFiles: number): void {
+function walkDir(dir: string, matcher: IgnoreMatcher, files: WalkedFile[], maxFiles: number): void {
   if (files.length >= maxFiles) return;
 
   let entries: string[];
@@ -73,15 +66,15 @@ function walkDir(dir: string, exclude: string[], files: WalkedFile[], maxFiles: 
 
   for (const entry of entries) {
     if (files.length >= maxFiles) return;
-    if (exclude.some((ex) => entry === ex || entry.startsWith('.'))) continue;
-
     const fullPath = join(dir, entry);
 
     try {
       const stat = statSync(fullPath);
       if (stat.isDirectory()) {
-        walkDir(fullPath, exclude, files, maxFiles);
+        if (matcher.isIgnored(fullPath + '/')) continue;
+        walkDir(fullPath, matcher, files, maxFiles);
       } else if (stat.isFile()) {
+        if (matcher.isIgnored(fullPath)) continue;
         const ext = entry.split('.').pop()?.toLowerCase() ?? '';
         if (!ANALYZABLE_EXTENSIONS.has(ext)) continue;
         if (stat.size > 500_000) continue; // Skip files > 500KB

--- a/src/utils/ignore.ts
+++ b/src/utils/ignore.ts
@@ -1,0 +1,182 @@
+/**
+ * Project-wide ignore matcher.
+ *
+ * Loads `.vguardignore` from the project root (if present), merges it with
+ * hardcoded defaults, and exposes a single `isIgnored(path)` helper used by
+ * the lint scanner, runtime hooks, the learn walker, and the cloud sync
+ * exclusions. One matcher is cached per project root so the file is only
+ * read once per process.
+ *
+ * Behaviour mirrors `.gitignore` because it is powered by the `ignore`
+ * package (the de-facto standard used by ESLint, Prettier, stylelint).
+ * That means negation (`!pattern`), directory suffixes (`foo/`), glob
+ * wildcards (`**`, `*`, `?`), and comments (`# …`) all work.
+ *
+ * Fail-open: any error while reading or parsing falls back to a matcher
+ * that only knows the hardcoded defaults. A missing `.vguardignore` is
+ * expected and never warns.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { isAbsolute, join, relative, resolve } from 'node:path';
+
+import ignorePkg from 'ignore';
+
+import { normalizePath } from './path.js';
+
+/** The filename we look for in the project root. */
+export const VGUARD_IGNORE_FILENAME = '.vguardignore';
+
+/**
+ * Hardcoded defaults that every project should ignore — these match the
+ * paths that the pre-matcher scanner used to hardcode in DEFAULT_EXCLUDE.
+ * They can still be overridden by the user's `.vguardignore` (via `!`
+ * negation) if a legitimate use case arises.
+ */
+export const HARDCODED_DEFAULTS: readonly string[] = [
+  'node_modules/',
+  '.next/',
+  'dist/',
+  'build/',
+  '.git/',
+  'coverage/',
+  '.vguard/',
+  '.turbo/',
+  '__pycache__/',
+  '.venv/',
+] as const;
+
+export interface IgnoreMatcher {
+  /**
+   * Returns `true` if the given file path (absolute or relative) should
+   * be ignored by all VGuard execution paths.
+   */
+  isIgnored(filePath: string): boolean;
+  /** Active patterns (defaults + file + extras) — exposed for `vguard doctor`. */
+  patterns: string[];
+  /** Was a `.vguardignore` actually loaded from disk? */
+  hasFile: boolean;
+  /**
+   * Which patterns came from the `.vguardignore` file
+   * (not the hardcoded defaults, not the extras).
+   */
+  filePatterns: string[];
+  /** Project root this matcher was built for (absolute, normalised). */
+  projectRoot: string;
+}
+
+/** Per-projectRoot cache so multiple callers re-use one matcher. */
+const matcherCache = new Map<string, IgnoreMatcher>();
+
+/**
+ * Build (or return cached) matcher for the given project root.
+ *
+ * @param projectRoot Absolute path to the project root.
+ * @param extraPatterns Additional patterns to merge in on top of the file
+ *   + defaults. Used by the learn walker (`learn.ignorePaths`) and the
+ *   cloud sync privacy filter (`cloud.excludePaths`) to bridge their
+ *   legacy config fields into the new unified matcher.
+ */
+export function createIgnoreMatcher(
+  projectRoot: string,
+  extraPatterns: readonly string[] = [],
+): IgnoreMatcher {
+  const absRoot = resolve(projectRoot);
+  // Extras change per-caller, so we can only cache when they are absent.
+  const canCache = extraPatterns.length === 0;
+
+  if (canCache) {
+    const cached = matcherCache.get(absRoot);
+    if (cached) return cached;
+  }
+
+  let filePatterns: string[] = [];
+  let hasFile = false;
+
+  try {
+    const ignorePath = join(absRoot, VGUARD_IGNORE_FILENAME);
+    if (existsSync(ignorePath)) {
+      const raw = readFileSync(ignorePath, 'utf-8');
+      filePatterns = parseIgnoreFile(raw);
+      hasFile = true;
+    }
+  } catch {
+    // Fail-open — fall back to defaults only.
+    filePatterns = [];
+    hasFile = false;
+  }
+
+  const patterns = [...HARDCODED_DEFAULTS, ...filePatterns, ...extraPatterns];
+
+  // `ignore()` returns its own type; its `add()` accepts comma- or newline-
+  // separated strings OR arrays. It silently skips empty lines + comments.
+  const ig = ignorePkg();
+  try {
+    ig.add(patterns);
+  } catch {
+    // Shouldn't happen with string patterns, but stay fail-open.
+  }
+
+  const matcher: IgnoreMatcher = {
+    patterns,
+    hasFile,
+    filePatterns,
+    projectRoot: absRoot,
+    isIgnored(filePath: string): boolean {
+      try {
+        const rel = toRelativePath(absRoot, filePath);
+        // The ignore package refuses empty strings, `./`, and paths that
+        // escape the project root (`../…`). None of those should ever be
+        // ignored — treat them as included.
+        if (!rel || rel.startsWith('..')) return false;
+        return ig.ignores(rel);
+      } catch {
+        return false;
+      }
+    },
+  };
+
+  if (canCache) {
+    matcherCache.set(absRoot, matcher);
+  }
+  return matcher;
+}
+
+/**
+ * Clear the in-memory matcher cache. Called by `vguard generate` so that
+ * user edits to `.vguardignore` propagate to the next lint/hook run
+ * without restarting the process, and by tests for isolation.
+ */
+export function clearIgnoreMatcherCache(): void {
+  matcherCache.clear();
+}
+
+/**
+ * Parse raw `.vguardignore` content into a list of non-empty, non-comment
+ * pattern lines. Blank lines and `# …` comments are stripped here so the
+ * `patterns` array exposed on the matcher is useful for humans (via
+ * `vguard doctor` + `vguard ignore list`).
+ */
+function parseIgnoreFile(raw: string): string[] {
+  return raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#'));
+}
+
+/**
+ * Convert an arbitrary file path to a forward-slashed, project-root-relative
+ * path suitable for feeding to the `ignore` package.
+ *
+ * - Absolute path → made relative to projectRoot.
+ * - Relative path → left alone (assumed to already be relative to projectRoot).
+ * - Windows backslashes → forward slashes.
+ */
+function toRelativePath(projectRoot: string, filePath: string): string {
+  const normalised = normalizePath(filePath);
+  if (isAbsolute(filePath)) {
+    return normalizePath(relative(projectRoot, filePath));
+  }
+  // Strip any leading ./
+  return normalised.replace(/^\.\//, '');
+}

--- a/tests/cli/ignore.test.ts
+++ b/tests/cli/ignore.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  ignoreListCommand,
+  ignoreAddCommand,
+  ignoreRemoveCommand,
+  ignoreCheckCommand,
+  ignoreInitCommand,
+} from '../../src/cli/commands/ignore.js';
+import { clearIgnoreMatcherCache } from '../../src/utils/ignore.js';
+
+const IGNORE_FILE = '.vguardignore';
+
+let projectRoot: string;
+let originalCwd: string;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  projectRoot = mkdtempSync(join(tmpdir(), 'vguard-ignore-cmd-'));
+  originalCwd = process.cwd();
+  process.chdir(projectRoot);
+  clearIgnoreMatcherCache();
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+    throw new Error('exit');
+  }) as never);
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  errorSpy.mockRestore();
+  exitSpy.mockRestore();
+  process.chdir(originalCwd);
+  clearIgnoreMatcherCache();
+  rmSync(projectRoot, { recursive: true, force: true });
+});
+
+function readIgnoreFile(): string {
+  return readFileSync(join(projectRoot, IGNORE_FILE), 'utf-8');
+}
+
+describe('vguard ignore init', () => {
+  it('creates .vguardignore with default template', async () => {
+    await ignoreInitCommand();
+    expect(existsSync(join(projectRoot, IGNORE_FILE))).toBe(true);
+    const content = readIgnoreFile();
+    expect(content).toContain('# VGuard ignore');
+    expect(content).toContain('.DS_Store');
+  });
+
+  it('does not overwrite an existing file', async () => {
+    writeFileSync(join(projectRoot, IGNORE_FILE), 'custom-content\n', 'utf-8');
+    await ignoreInitCommand();
+    expect(readIgnoreFile()).toBe('custom-content\n');
+  });
+});
+
+describe('vguard ignore add', () => {
+  it('creates .vguardignore if missing and appends the pattern', async () => {
+    await ignoreAddCommand('src/components/ui/');
+    const content = readIgnoreFile();
+    expect(content).toContain('src/components/ui/');
+    expect(content).toContain('# VGuard ignore'); // template header
+  });
+
+  it('appends to existing .vguardignore', async () => {
+    writeFileSync(join(projectRoot, IGNORE_FILE), '# header\nexisting/\n', 'utf-8');
+    await ignoreAddCommand('another/');
+    const content = readIgnoreFile();
+    expect(content).toContain('existing/');
+    expect(content).toContain('another/');
+  });
+
+  it('refuses duplicates (no write, no error)', async () => {
+    writeFileSync(join(projectRoot, IGNORE_FILE), 'already-here/\n', 'utf-8');
+    await ignoreAddCommand('already-here/');
+    const content = readIgnoreFile();
+    // Should still contain exactly one occurrence.
+    expect(content.match(/already-here\//g)).toHaveLength(1);
+  });
+
+  it('rejects empty patterns', async () => {
+    await expect(ignoreAddCommand('   ')).rejects.toThrow('exit');
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('empty'));
+  });
+
+  it('rejects comment-only patterns', async () => {
+    await expect(ignoreAddCommand('# nope')).rejects.toThrow('exit');
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('comment'));
+  });
+});
+
+describe('vguard ignore remove', () => {
+  it('removes an exact matching line', async () => {
+    writeFileSync(
+      join(projectRoot, IGNORE_FILE),
+      '# header\nkeep-me/\nremove-me/\nalso-keep/\n',
+      'utf-8',
+    );
+    await ignoreRemoveCommand('remove-me/');
+    const content = readIgnoreFile();
+    expect(content).toContain('keep-me/');
+    expect(content).toContain('also-keep/');
+    expect(content).toContain('# header');
+    expect(content).not.toContain('remove-me/');
+  });
+
+  it('no-ops when pattern is not present', async () => {
+    writeFileSync(join(projectRoot, IGNORE_FILE), 'a/\nb/\n', 'utf-8');
+    await ignoreRemoveCommand('nonexistent/');
+    const content = readIgnoreFile();
+    expect(content).toBe('a/\nb/\n');
+  });
+
+  it('no-ops when file does not exist', async () => {
+    await ignoreRemoveCommand('anything/');
+    expect(existsSync(join(projectRoot, IGNORE_FILE))).toBe(false);
+  });
+
+  it('rejects empty patterns', async () => {
+    await expect(ignoreRemoveCommand('  ')).rejects.toThrow('exit');
+  });
+});
+
+describe('vguard ignore list', () => {
+  it('prints defaults and file patterns', () => {
+    writeFileSync(join(projectRoot, IGNORE_FILE), 'src/components/ui/\n*.log\n', 'utf-8');
+    ignoreListCommand();
+
+    const output = logSpy.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('[default]');
+    expect(output).toContain('node_modules/');
+    expect(output).toContain('.vguardignore');
+    expect(output).toContain('src/components/ui/');
+    expect(output).toContain('*.log');
+  });
+
+  it('reports when no .vguardignore exists', () => {
+    ignoreListCommand();
+    const output = logSpy.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('(not found)');
+    expect(output).toContain('vguard ignore init');
+  });
+});
+
+describe('vguard ignore check', () => {
+  it('reports a default-matched path as ignored', () => {
+    ignoreCheckCommand('node_modules/foo/index.js');
+    const output = logSpy.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('ignored');
+    expect(output).toContain('built-in default');
+  });
+
+  it('reports a .vguardignore-matched path as ignored', () => {
+    writeFileSync(join(projectRoot, IGNORE_FILE), 'src/components/ui/\n', 'utf-8');
+    clearIgnoreMatcherCache();
+    ignoreCheckCommand('src/components/ui/button.tsx');
+    const output = logSpy.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('ignored');
+    expect(output).toContain('.vguardignore');
+  });
+
+  it('reports a non-matching path as included', () => {
+    ignoreCheckCommand('src/app/page.tsx');
+    const output = logSpy.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('included');
+    expect(output).toContain('no pattern matched');
+  });
+
+  it('rejects empty path', () => {
+    expect(() => ignoreCheckCommand('')).toThrow('exit');
+  });
+});

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -144,4 +144,25 @@ describe('initCommand', () => {
     );
     consoleSpy.mockRestore();
   });
+
+  it('writes .vguardignore when none exists', async () => {
+    vi.mocked(inquirer.prompt)
+      .mockResolvedValueOnce({
+        presets: [],
+        agents: ['claude-code'],
+        protectedBranches: 'main',
+      })
+      .mockResolvedValueOnce({ folders: [] })
+      .mockResolvedValueOnce({ enableCloud: false });
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await initCommand();
+
+    expect(writeFile).toHaveBeenCalledWith(
+      expect.stringContaining('.vguardignore'),
+      expect.stringContaining('VGuard ignore'),
+      'utf-8',
+    );
+    consoleSpy.mockRestore();
+  });
 });

--- a/tests/cloud/sync.test.ts
+++ b/tests/cloud/sync.test.ts
@@ -45,9 +45,11 @@ describe('cloud/sync', () => {
   });
 
   describe('applyExclusions', () => {
+    const projectRoot = '/project';
+
     it('should return records unchanged when no exclusions', () => {
       const records = [makeRecord()];
-      const result = applyExclusions(records, []);
+      const result = applyExclusions(records, projectRoot, []);
       expect(result[0].filePath).toBe('/project/src/index.ts');
     });
 
@@ -56,7 +58,7 @@ describe('cloud/sync', () => {
         makeRecord({ filePath: '/project/secrets/api-key.json' }),
         makeRecord({ filePath: '/project/src/index.ts' }),
       ];
-      const result = applyExclusions(records, ['**/secrets/**']);
+      const result = applyExclusions(records, projectRoot, ['secrets/']);
       expect(result[0].filePath).toBeUndefined();
       expect(result[1].filePath).toBe('/project/src/index.ts');
     });
@@ -66,14 +68,14 @@ describe('cloud/sync', () => {
         makeRecord({ filePath: '/project/src/index.ts' }),
         makeRecord({ filePath: '/project/lib/utils.ts' }),
       ];
-      const result = applyExclusions(records, ['**/*']);
+      const result = applyExclusions(records, projectRoot, ['**/*']);
       expect(result[0].filePath).toBeUndefined();
       expect(result[1].filePath).toBeUndefined();
     });
 
     it('should preserve records with no filePath', () => {
       const records = [makeRecord({ filePath: undefined })];
-      const result = applyExclusions(records, ['**/*']);
+      const result = applyExclusions(records, projectRoot, ['**/*']);
       expect(result).toHaveLength(1);
     });
   });

--- a/tests/integration/hook-execution.test.ts
+++ b/tests/integration/hook-execution.test.ts
@@ -58,6 +58,16 @@ vi.mock('../../src/utils/validation.js', () => ({
   isValidHookEvent: vi.fn((e: string) => ['PreToolUse', 'PostToolUse', 'Stop'].includes(e)),
 }));
 
+vi.mock('../../src/utils/ignore.js', () => ({
+  createIgnoreMatcher: vi.fn(() => ({
+    isIgnored: vi.fn(() => false),
+    patterns: [],
+    filePatterns: [],
+    hasFile: false,
+    projectRoot: '/project',
+  })),
+}));
+
 // Mock rule imports (side-effect only)
 vi.mock('../../src/rules/index.js', () => ({}));
 
@@ -67,6 +77,7 @@ import { resolveRules } from '../../src/engine/resolver.js';
 import { runRules } from '../../src/engine/runner.js';
 import { recordPerfEntry } from '../../src/engine/perf.js';
 import { formatPreToolUseOutput } from '../../src/engine/output.js';
+import { createIgnoreMatcher } from '../../src/utils/ignore.js';
 
 describe('Hook Execution Integration', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
@@ -105,6 +116,33 @@ describe('Hook Execution Integration', () => {
 
     await expect(executeHook('PreToolUse')).rejects.toThrow('process.exit called');
     expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('exits 0 when tool_input.file_path matches .vguardignore', async () => {
+    vi.mocked(parseStdinJson).mockReturnValue({
+      tool_name: 'Edit',
+      tool_input: { file_path: '/project/src/components/ui/button.tsx' },
+    });
+    vi.mocked(loadCompiledConfig).mockResolvedValue({
+      presets: [],
+      agents: ['claude-code'],
+      rules: new Map(),
+    });
+    vi.mocked(createIgnoreMatcher).mockReturnValueOnce({
+      isIgnored: vi.fn(() => true),
+      patterns: ['src/components/ui/'],
+      filePatterns: ['src/components/ui/'],
+      hasFile: true,
+      projectRoot: '/project',
+    });
+
+    const { executeHook } = await import('../../src/engine/hook-entry.js');
+    await expect(executeHook('PreToolUse')).rejects.toThrow('process.exit called');
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    // Rule resolution / execution must be skipped.
+    expect(resolveRules).not.toHaveBeenCalled();
+    expect(runRules).not.toHaveBeenCalled();
+    expect(recordPerfEntry).not.toHaveBeenCalled();
   });
 
   it('exits 0 when no matching rules', async () => {

--- a/tests/utils/ignore.test.ts
+++ b/tests/utils/ignore.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  createIgnoreMatcher,
+  clearIgnoreMatcherCache,
+  HARDCODED_DEFAULTS,
+  VGUARD_IGNORE_FILENAME,
+} from '../../src/utils/ignore.js';
+
+let projectRoot: string;
+
+function write(name: string, content: string) {
+  writeFileSync(join(projectRoot, name), content, 'utf-8');
+}
+
+beforeEach(() => {
+  projectRoot = mkdtempSync(join(tmpdir(), 'vguard-ignore-'));
+  clearIgnoreMatcherCache();
+});
+
+afterEach(() => {
+  clearIgnoreMatcherCache();
+  rmSync(projectRoot, { recursive: true, force: true });
+});
+
+describe('createIgnoreMatcher', () => {
+  describe('defaults-only (no .vguardignore)', () => {
+    it('ignores every hardcoded default', () => {
+      const m = createIgnoreMatcher(projectRoot);
+      expect(m.hasFile).toBe(false);
+      expect(m.filePatterns).toEqual([]);
+
+      for (const pattern of HARDCODED_DEFAULTS) {
+        // Probe a file inside each default directory.
+        const probe = join(projectRoot, pattern.replace(/\/$/, ''), 'foo.ts');
+        expect(m.isIgnored(probe)).toBe(true);
+      }
+    });
+
+    it('does not ignore ordinary source paths', () => {
+      const m = createIgnoreMatcher(projectRoot);
+      expect(m.isIgnored(join(projectRoot, 'src/index.ts'))).toBe(false);
+      expect(m.isIgnored(join(projectRoot, 'README.md'))).toBe(false);
+    });
+
+    it('does not mis-fire on similarly-named directories', () => {
+      const m = createIgnoreMatcher(projectRoot);
+      // node-utils is not node_modules
+      expect(m.isIgnored(join(projectRoot, 'src/node-utils/foo.ts'))).toBe(false);
+    });
+  });
+
+  describe('with a .vguardignore file', () => {
+    it('loads user patterns on top of defaults', () => {
+      write(VGUARD_IGNORE_FILENAME, 'src/components/ui/\nsupabase/migrations/\n');
+
+      const m = createIgnoreMatcher(projectRoot);
+      expect(m.hasFile).toBe(true);
+      expect(m.filePatterns).toEqual(['src/components/ui/', 'supabase/migrations/']);
+
+      expect(m.isIgnored(join(projectRoot, 'src/components/ui/button.tsx'))).toBe(true);
+      expect(m.isIgnored(join(projectRoot, 'supabase/migrations/20260101_init.sql'))).toBe(true);
+      // Still honours defaults.
+      expect(m.isIgnored(join(projectRoot, 'node_modules/foo/index.js'))).toBe(true);
+      // Other paths remain.
+      expect(m.isIgnored(join(projectRoot, 'src/app/page.tsx'))).toBe(false);
+    });
+
+    it('strips blank lines and # comments from filePatterns', () => {
+      write(VGUARD_IGNORE_FILENAME, '# Header comment\n\ndist-custom/\n\n# Another\n*.log\n');
+
+      const m = createIgnoreMatcher(projectRoot);
+      expect(m.filePatterns).toEqual(['dist-custom/', '*.log']);
+    });
+
+    it('supports glob patterns anywhere in the tree', () => {
+      write(VGUARD_IGNORE_FILENAME, '**/*.generated.ts\n**/__snapshots__/\n');
+
+      const m = createIgnoreMatcher(projectRoot);
+      expect(m.isIgnored(join(projectRoot, 'src/foo.generated.ts'))).toBe(true);
+      expect(m.isIgnored(join(projectRoot, 'deep/nested/bar.generated.ts'))).toBe(true);
+      expect(m.isIgnored(join(projectRoot, 'src/__snapshots__/test.snap'))).toBe(true);
+      expect(m.isIgnored(join(projectRoot, 'src/normal.ts'))).toBe(false);
+    });
+
+    it('supports negation patterns to un-ignore files', () => {
+      // gitignore semantics: file-pattern ignore + negation works. Directory-level
+      // ignores cannot be un-ignored for contained files — that is a documented
+      // gitignore limitation, so we test file-glob negation.
+      write(VGUARD_IGNORE_FILENAME, '*.log\n!important.log\n');
+
+      const m = createIgnoreMatcher(projectRoot);
+      expect(m.isIgnored(join(projectRoot, 'debug.log'))).toBe(true);
+      expect(m.isIgnored(join(projectRoot, 'important.log'))).toBe(false);
+    });
+  });
+
+  describe('path normalisation', () => {
+    it('accepts absolute paths and converts to project-relative', () => {
+      write(VGUARD_IGNORE_FILENAME, 'custom-dir/\n');
+      const m = createIgnoreMatcher(projectRoot);
+      expect(m.isIgnored(join(projectRoot, 'custom-dir/file.ts'))).toBe(true);
+    });
+
+    it('accepts relative paths from projectRoot', () => {
+      write(VGUARD_IGNORE_FILENAME, 'custom-dir/\n');
+      const m = createIgnoreMatcher(projectRoot);
+      expect(m.isIgnored('custom-dir/file.ts')).toBe(true);
+    });
+
+    it('handles paths with backslashes (Windows-style)', () => {
+      write(VGUARD_IGNORE_FILENAME, 'custom-dir/\n');
+      const m = createIgnoreMatcher(projectRoot);
+      expect(m.isIgnored('custom-dir\\file.ts')).toBe(true);
+    });
+
+    it('does not ignore paths outside the project root', () => {
+      const m = createIgnoreMatcher(projectRoot);
+      // Path that resolves to parent dirs should not match.
+      expect(m.isIgnored('/completely/elsewhere/node_modules/foo.ts')).toBe(false);
+    });
+  });
+
+  describe('caching', () => {
+    it('returns the same matcher instance for the same projectRoot', () => {
+      const a = createIgnoreMatcher(projectRoot);
+      const b = createIgnoreMatcher(projectRoot);
+      expect(a).toBe(b);
+    });
+
+    it('does not cache when extraPatterns are provided', () => {
+      const a = createIgnoreMatcher(projectRoot, ['extra/']);
+      const b = createIgnoreMatcher(projectRoot, ['extra/']);
+      expect(a).not.toBe(b);
+    });
+
+    it('rebuilds after clearIgnoreMatcherCache()', () => {
+      const first = createIgnoreMatcher(projectRoot);
+      clearIgnoreMatcherCache();
+      const second = createIgnoreMatcher(projectRoot);
+      expect(first).not.toBe(second);
+    });
+
+    it('picks up new .vguardignore file after cache is cleared', () => {
+      const before = createIgnoreMatcher(projectRoot);
+      expect(before.isIgnored(join(projectRoot, 'src/x.ts'))).toBe(false);
+
+      write(VGUARD_IGNORE_FILENAME, 'src/\n');
+      clearIgnoreMatcherCache();
+
+      const after = createIgnoreMatcher(projectRoot);
+      expect(after.hasFile).toBe(true);
+      expect(after.isIgnored(join(projectRoot, 'src/x.ts'))).toBe(true);
+    });
+  });
+
+  describe('extraPatterns', () => {
+    it('merges extras with defaults + file patterns', () => {
+      write(VGUARD_IGNORE_FILENAME, 'file-pattern/\n');
+      const m = createIgnoreMatcher(projectRoot, ['extra-pattern/']);
+      expect(m.isIgnored(join(projectRoot, 'node_modules/x.ts'))).toBe(true); // default
+      expect(m.isIgnored(join(projectRoot, 'file-pattern/x.ts'))).toBe(true); // file
+      expect(m.isIgnored(join(projectRoot, 'extra-pattern/x.ts'))).toBe(true); // extra
+    });
+
+    it('does not permanently alter the shared cache', () => {
+      createIgnoreMatcher(projectRoot, ['extra-pattern/']);
+      const plain = createIgnoreMatcher(projectRoot);
+      expect(plain.isIgnored(join(projectRoot, 'extra-pattern/x.ts'))).toBe(false);
+    });
+  });
+
+  describe('fail-open behaviour', () => {
+    it('falls back to defaults when .vguardignore is unreadable', () => {
+      // Write a directory at the path of .vguardignore to force a read failure.
+      // (Easier: write valid content, then simulate via no file at all.)
+      // Instead, just make sure a missing file does not throw.
+      const m = createIgnoreMatcher(projectRoot);
+      expect(m.hasFile).toBe(false);
+      expect(m.isIgnored(join(projectRoot, 'node_modules/a.ts'))).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a \`.vguardignore\` file at the project root with full gitignore syntax. One file excludes files/folders from **every** vguard execution path — \`vguard lint\`, Claude Code runtime hooks (PreToolUse/PostToolUse), and \`vguard learn\`. Resolves the common complaint that shadcn/ui auto-generated components and frozen SQL migrations surfaced false-positive violations with no clean project-wide opt-out.

**Symptom that triggered this** (from Lumioh's \`vguard-violations.txt\`): 4,770 files scanned, 60+ violations in \`src/components/ui/\*\*\`, 88+ in \`supabase/migrations/\*\*\` — all unreachable from the existing config options.

**Version:** 1.4.1 → **1.7.0** (new feature, minor bump).

## What's new

### Core infrastructure

- **\`src/utils/ignore.ts\`** — new \`IgnoreMatcher\` backed by the \`ignore\` npm package (~8KB MIT, the same one ESLint/Prettier use). Reads \`.vguardignore\`, merges with hardcoded defaults, cached per project root, fail-open.
- **Scanner, hooks, and learn walker** all now consult the single matcher.
- **Hook short-circuit**: when \`tool_input.file_path\` matches an ignore pattern, \`hook-entry.ts\` exits 0 **before** rules run or tracking records. No more shadcn blocks.

### \`vguard init\` starter file

Creates a starter \`.vguardignore\` with active defaults (generated-code globs, IDE/OS cruft) + commented hints for common opt-ins (\`src/components/ui/\`, \`supabase/migrations/\`, snapshots, fixtures).

### New \`vguard ignore\` subcommand

| | |
|---|---|
| \`vguard ignore list\` | Active patterns grouped by source |
| \`vguard ignore add <pattern>\` | Append (creates file if missing, dedupes) |
| \`vguard ignore remove <pattern>\` | Remove exact line, preserves comments |
| \`vguard ignore check <path>\` | Reports matching pattern + its source |
| \`vguard ignore init\` | Create the file standalone |

### Legacy field integration

- \`learn.ignorePaths\` and \`cloud.excludePaths\` config fields now merge into the matcher via \`extraPatterns\` — they compose with \`.vguardignore\` instead of being siloed.
- \`vguard doctor\` reports \`.vguardignore\` status + pattern count, and prints deprecation hints when either legacy field is set.

## Test Plan

- [x] 694 → **731 passing** (18 matcher unit + 17 subcommand + 1 hook-entry short-circuit + 1 init-writes-file)
- [x] \`npm run lint\` clean
- [x] \`npm run type-check\` clean
- [x] \`npm run format:check\` clean
- [x] \`npm run build\` clean (ESM + CJS)
- [x] Manual smoke test: \`ignore init → ignore add → ignore list → ignore check\` round-trip works in an empty scratch directory

## Dependency

Adds \`ignore@^7.0.5\` as a runtime dependency. Tiny, MIT, zero transitive deps.

## Out of scope

- Reading \`.gitignore\` (explicit only — header comment points users at their own .gitignore if they want to copy entries)
- Per-workspace monorepo package overrides (single root file for now)
- Removing the legacy \`learn.ignorePaths\` / \`cloud.excludePaths\` config fields (bridged for now, removal deferred to v2.0)

## Deployment

Standard release flow: merge to \`dev\`, release PR to \`master\`, npm publish. No cloud-side changes required.