### PR TITLE
fix(cli): add missing commands and fix upgrade — v1.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solanticai/vguard",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "AI coding guardrails framework. Runtime-enforced quality controls for Claude Code, Cursor, Codex, and more.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1,0 +1,133 @@
+import '../../presets/index.js';
+import '../../rules/index.js';
+
+import { discoverConfigFile, readRawConfig } from '../../config/discovery.js';
+import { resolveConfig } from '../../config/loader.js';
+import { getAllPresets } from '../../config/presets.js';
+import type { VGuardConfig } from '../../types.js';
+
+export async function configShowCommand(options: { json?: boolean; raw?: boolean }): Promise<void> {
+  const projectRoot = process.cwd();
+
+  const discovered = discoverConfigFile(projectRoot);
+  if (!discovered) {
+    console.error('  No VGuard config found. Run `vguard init` first.');
+    process.exit(1);
+  }
+
+  const rawConfig = (await readRawConfig(discovered)) as VGuardConfig;
+
+  if (options.raw) {
+    if (options.json) {
+      console.log(JSON.stringify(rawConfig, null, 2));
+    } else {
+      console.log('\n  VGuard Config (raw)\n');
+      console.log(`  Source: ${discovered.path}\n`);
+      console.log(JSON.stringify(rawConfig, null, 2));
+      console.log();
+    }
+    return;
+  }
+
+  // Resolve config with presets applied
+  const presetMap = getAllPresets();
+  const resolved = resolveConfig(rawConfig, presetMap);
+
+  if (options.json) {
+    const output = {
+      source: discovered.path,
+      presets: resolved.presets,
+      agents: resolved.agents,
+      rules: Object.fromEntries(
+        Array.from(resolved.rules.entries()).map(([id, config]) => [
+          id,
+          { enabled: config.enabled, severity: config.severity },
+        ]),
+      ),
+      cloud: resolved.cloud ?? null,
+    };
+    console.log(JSON.stringify(output, null, 2));
+    return;
+  }
+
+  console.log('\n  VGuard Config (resolved)\n');
+  console.log(`  Source:  ${discovered.path}`);
+  console.log(`  Presets: ${resolved.presets.length > 0 ? resolved.presets.join(', ') : 'none'}`);
+  console.log(`  Agents:  ${resolved.agents.join(', ')}`);
+  console.log();
+
+  // Rules summary
+  const enabledRules = Array.from(resolved.rules.entries()).filter(([, c]) => c.enabled);
+  const disabledRules = Array.from(resolved.rules.entries()).filter(([, c]) => !c.enabled);
+
+  console.log(`  Rules: ${enabledRules.length} enabled, ${disabledRules.length} disabled`);
+  console.log();
+
+  if (enabledRules.length > 0) {
+    console.log('  Enabled:');
+    for (const [id, config] of enabledRules.sort(([a], [b]) => a.localeCompare(b))) {
+      console.log(`    \u2713 ${id.padEnd(40)} ${config.severity}`);
+    }
+    console.log();
+  }
+
+  if (disabledRules.length > 0) {
+    console.log('  Disabled:');
+    for (const [id] of disabledRules.sort(([a], [b]) => a.localeCompare(b))) {
+      console.log(`    \u2717 ${id}`);
+    }
+    console.log();
+  }
+
+  // Cloud status
+  if (resolved.cloud) {
+    console.log('  Cloud:');
+    console.log(`    Enabled:   ${resolved.cloud.enabled ?? false}`);
+    console.log(`    Auto-sync: ${resolved.cloud.autoSync ?? false}`);
+    console.log();
+  }
+}
+
+export async function configSetCommand(key: string, value: string): Promise<void> {
+  const projectRoot = process.cwd();
+
+  const discovered = discoverConfigFile(projectRoot);
+  if (!discovered) {
+    console.error('  No VGuard config found. Run `vguard init` first.');
+    process.exit(1);
+  }
+
+  if (!discovered.path.endsWith('.json')) {
+    console.log(`\n  TypeScript configs cannot be modified programmatically.`);
+    console.log(`  Edit ${discovered.path} directly and set "${key}" to "${value}".\n`);
+    return;
+  }
+
+  const { readFile, writeFile } = await import('node:fs/promises');
+  const raw = await readFile(discovered.path, 'utf-8');
+  const config = JSON.parse(raw);
+
+  // Support dot-notation (e.g., "cloud.autoSync")
+  const keys = key.split('.');
+  let target = config;
+  for (let i = 0; i < keys.length - 1; i++) {
+    target[keys[i]] = target[keys[i]] ?? {};
+    target = target[keys[i]];
+  }
+
+  // Parse value type
+  const finalKey = keys[keys.length - 1];
+  if (value === 'true') {
+    target[finalKey] = true;
+  } else if (value === 'false') {
+    target[finalKey] = false;
+  } else if (/^\d+$/.test(value)) {
+    target[finalKey] = parseInt(value, 10);
+  } else {
+    target[finalKey] = value;
+  }
+
+  await writeFile(discovered.path, JSON.stringify(config, null, 2), 'utf-8');
+  console.log(`  Set ${key} = ${value}`);
+  console.log('  Run `vguard generate` to apply changes.\n');
+}

--- a/src/cli/commands/presets.ts
+++ b/src/cli/commands/presets.ts
@@ -1,0 +1,70 @@
+import '../../presets/index.js';
+import '../../rules/index.js';
+
+import { getAllPresets } from '../../config/presets.js';
+import { discoverConfigFile, readRawConfig } from '../../config/discovery.js';
+import { resolveConfig } from '../../config/loader.js';
+import type { VGuardConfig } from '../../types.js';
+import { addCommand } from './add.js';
+import { removeCommand } from './remove.js';
+
+export async function presetsListCommand(options: { installed?: boolean }): Promise<void> {
+  const projectRoot = process.cwd();
+  const allPresets = getAllPresets();
+
+  // Determine which presets are active in the current config
+  let activePresetIds = new Set<string>();
+
+  const discovered = discoverConfigFile(projectRoot);
+  if (discovered) {
+    try {
+      const rawConfig = (await readRawConfig(discovered)) as VGuardConfig;
+      const presetMap = getAllPresets();
+      const resolved = resolveConfig(rawConfig, presetMap);
+      activePresetIds = new Set(resolved.presets);
+    } catch {
+      // Config errors are non-fatal for listing
+    }
+  }
+
+  const presets = Array.from(allPresets.entries())
+    .map(([id, preset]) => ({
+      id,
+      name: preset.name,
+      description: preset.description,
+      version: preset.version,
+      installed: activePresetIds.has(id),
+      ruleCount: Object.keys(preset.rules).length,
+    }))
+    .filter((p) => !options.installed || p.installed)
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  if (presets.length === 0) {
+    console.log('\n  No presets found.');
+    if (options.installed) {
+      console.log('  Remove --installed to see all available presets.\n');
+    }
+    return;
+  }
+
+  console.log('\n  VGuard Presets\n');
+
+  for (const preset of presets) {
+    const status = preset.installed ? '\u2713' : ' ';
+    console.log(`  ${status} ${preset.id.padEnd(25)} ${preset.name}`);
+    console.log(`    ${preset.description}`);
+    console.log(`    ${preset.ruleCount} rules | v${preset.version}`);
+    console.log();
+  }
+
+  const installed = presets.filter((p) => p.installed).length;
+  console.log(`  ${installed}/${allPresets.size} presets installed.\n`);
+}
+
+export async function presetsAddCommand(presetId: string): Promise<void> {
+  await addCommand(`preset:${presetId}`);
+}
+
+export async function presetsRemoveCommand(presetId: string): Promise<void> {
+  await removeCommand(`preset:${presetId}`);
+}

--- a/src/cli/commands/report.ts
+++ b/src/cli/commands/report.ts
@@ -1,7 +1,12 @@
+import { writeFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
 import { aggregateReport } from '../../report/aggregator.js';
 import { generateMarkdownReport, saveReport } from '../../report/markdown.js';
 
-export async function reportCommand(): Promise<void> {
+export async function reportCommand(options?: {
+  output?: string;
+  format?: string;
+}): Promise<void> {
   const projectRoot = process.cwd();
 
   console.log('\n  VGuard Report — Generating quality dashboard...\n');
@@ -14,10 +19,33 @@ export async function reportCommand(): Promise<void> {
     return;
   }
 
-  const markdown = generateMarkdownReport(data);
-  const outputPath = await saveReport(markdown, projectRoot);
+  const format = options?.format ?? 'md';
 
-  console.log(`  Report saved to ${outputPath}`);
+  if (format === 'json') {
+    const json = JSON.stringify(data, null, 2);
+
+    if (options?.output) {
+      await mkdir(dirname(options.output), { recursive: true });
+      await writeFile(options.output, json, 'utf-8');
+      console.log(`  Report saved to ${options.output}`);
+    } else {
+      console.log(json);
+    }
+    return;
+  }
+
+  // Default: markdown
+  const markdown = generateMarkdownReport(data);
+
+  if (options?.output) {
+    await mkdir(dirname(options.output), { recursive: true });
+    await writeFile(options.output, markdown, 'utf-8');
+    console.log(`  Report saved to ${options.output}`);
+  } else {
+    const outputPath = await saveReport(markdown, projectRoot);
+    console.log(`  Report saved to ${outputPath}`);
+  }
+
   console.log(`  Total rule executions: ${data.totalHits}`);
   console.log(`  Technical debt score: ${data.debtScore}/100\n`);
 }

--- a/src/cli/commands/rules.ts
+++ b/src/cli/commands/rules.ts
@@ -1,0 +1,159 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+
+import '../../presets/index.js';
+import '../../rules/index.js';
+
+import { getAllRules } from '../../engine/registry.js';
+import { discoverConfigFile, readRawConfig } from '../../config/discovery.js';
+import { resolveConfig } from '../../config/loader.js';
+import { getAllPresets } from '../../config/presets.js';
+import type { VGuardConfig } from '../../types.js';
+
+export async function rulesListCommand(options: { all?: boolean; json?: boolean }): Promise<void> {
+  const projectRoot = process.cwd();
+  const allRules = getAllRules();
+
+  // Try to load config to determine which rules are enabled
+  const discovered = discoverConfigFile(projectRoot);
+  let enabledRuleIds = new Set<string>();
+
+  if (discovered) {
+    try {
+      const rawConfig = (await readRawConfig(discovered)) as VGuardConfig;
+      const presetMap = getAllPresets();
+      const resolved = resolveConfig(rawConfig, presetMap);
+      enabledRuleIds = new Set(
+        Array.from(resolved.rules.entries())
+          .filter(([, config]) => config.enabled)
+          .map(([id]) => id),
+      );
+    } catch {
+      // Config errors are non-fatal for listing
+    }
+  }
+
+  const rules = Array.from(allRules.entries())
+    .map(([id, rule]) => ({
+      id,
+      name: rule.name,
+      severity: rule.severity,
+      enabled: enabledRuleIds.has(id),
+      description: rule.description,
+    }))
+    .filter((r) => options.all || r.enabled)
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  if (options.json) {
+    console.log(JSON.stringify(rules, null, 2));
+    return;
+  }
+
+  if (rules.length === 0) {
+    console.log('\n  No rules found.');
+    if (!options.all) {
+      console.log('  Use --all to include disabled rules.\n');
+    }
+    return;
+  }
+
+  console.log('\n  VGuard Rules\n');
+
+  // Group by category
+  const grouped = new Map<string, typeof rules>();
+  for (const rule of rules) {
+    const category = rule.id.split('/')[0];
+    if (!grouped.has(category)) grouped.set(category, []);
+    grouped.get(category)!.push(rule);
+  }
+
+  for (const [category, categoryRules] of grouped) {
+    console.log(`  ${category}/`);
+    for (const rule of categoryRules) {
+      const status = rule.enabled ? '\u2713' : '\u2717';
+      const severityTag = rule.severity.toUpperCase().padEnd(5);
+      console.log(`    ${status} ${rule.id.padEnd(40)} ${severityTag}  ${rule.name}`);
+    }
+    console.log();
+  }
+
+  const enabled = rules.filter((r) => r.enabled).length;
+  const total = allRules.size;
+  console.log(`  ${enabled}/${total} rules enabled.`);
+  if (!options.all && total > enabled) {
+    console.log('  Use --all to include disabled rules.');
+  }
+  console.log();
+}
+
+export async function rulesEnableCommand(ruleId: string): Promise<void> {
+  const projectRoot = process.cwd();
+  const allRules = getAllRules();
+
+  if (!allRules.has(ruleId)) {
+    console.error(`  Unknown rule: "${ruleId}".`);
+    console.error('  Run `vguard rules list --all` to see available rules.');
+    process.exit(1);
+  }
+
+  const configPath = findConfigPath(projectRoot);
+  if (!configPath) {
+    console.error('  No VGuard config found. Run `vguard init` first.');
+    process.exit(1);
+  }
+
+  if (configPath.endsWith('.json')) {
+    const raw = await readFile(configPath, 'utf-8');
+    const config = JSON.parse(raw);
+    config.rules = config.rules ?? {};
+    config.rules[ruleId] = true;
+    await writeFile(configPath, JSON.stringify(config, null, 2), 'utf-8');
+    console.log(`  Enabled rule: ${ruleId}`);
+    console.log('  Run `vguard generate` to update hooks.\n');
+  } else {
+    console.log(`\n  Add the following to your vguard.config.ts:\n`);
+    console.log(`    rules: { '${ruleId}': true },`);
+    console.log(`\n  Then run \`vguard generate\` to update hooks.\n`);
+  }
+}
+
+export async function rulesDisableCommand(ruleId: string): Promise<void> {
+  const projectRoot = process.cwd();
+  const allRules = getAllRules();
+
+  if (!allRules.has(ruleId)) {
+    console.error(`  Unknown rule: "${ruleId}".`);
+    console.error('  Run `vguard rules list --all` to see available rules.');
+    process.exit(1);
+  }
+
+  const configPath = findConfigPath(projectRoot);
+  if (!configPath) {
+    console.error('  No VGuard config found. Run `vguard init` first.');
+    process.exit(1);
+  }
+
+  if (configPath.endsWith('.json')) {
+    const raw = await readFile(configPath, 'utf-8');
+    const config = JSON.parse(raw);
+    config.rules = config.rules ?? {};
+    config.rules[ruleId] = false;
+    await writeFile(configPath, JSON.stringify(config, null, 2), 'utf-8');
+    console.log(`  Disabled rule: ${ruleId}`);
+    console.log('  Run `vguard generate` to update hooks.\n');
+  } else {
+    console.log(`\n  Add the following to your vguard.config.ts:\n`);
+    console.log(`    rules: { '${ruleId}': false },`);
+    console.log(`\n  Then run \`vguard generate\` to update hooks.\n`);
+  }
+}
+
+function findConfigPath(projectRoot: string): string | null {
+  const candidates = ['vguard.config.ts', 'vguard.config.js', 'vguard.config.mjs', '.vguardrc.json'];
+  for (const file of candidates) {
+    const path = join(projectRoot, file);
+    if (existsSync(path)) return path;
+  }
+  return null;
+}

--- a/src/cli/commands/upgrade.ts
+++ b/src/cli/commands/upgrade.ts
@@ -8,7 +8,7 @@ export async function upgradeCommand(options: { check?: boolean; apply?: boolean
   console.log('\n  VGuard Upgrade\n');
 
   // Determine packages to check
-  const packagesToCheck = ['vguard'];
+  const packagesToCheck = ['@solanticai/vguard'];
 
   // Check for plugin packages
   const discovered = discoverConfigFile(projectRoot);
@@ -41,7 +41,7 @@ export async function upgradeCommand(options: { check?: boolean; apply?: boolean
   }
 
   // Show what's new (for the main VGuard package)
-  const mainUpdate = available.find((u) => u.name === 'vguard');
+  const mainUpdate = available.find((u) => u.name === '@solanticai/vguard');
   if (mainUpdate) {
     console.log('');
     displayVersionChanges(mainUpdate.current, mainUpdate.latest);

--- a/src/cli/commands/version.ts
+++ b/src/cli/commands/version.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export function versionCommand(): void {
+  try {
+    const pkg = JSON.parse(readFileSync(join(__dirname, '..', '..', '..', 'package.json'), 'utf-8'));
+    console.log(`vguard v${pkg.version}`);
+  } catch {
+    console.log('vguard v0.0.0 (unable to read version)');
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -79,11 +79,21 @@ program
   });
 
 program
+  .command('version')
+  .description('Display the installed VGuard CLI version')
+  .action(async () => {
+    const { versionCommand } = await import('./commands/version.js');
+    versionCommand();
+  });
+
+program
   .command('report')
   .description('Generate quality dashboard from rule hit data')
-  .action(async () => {
+  .option('--output <path>', 'Save report to a specific file path')
+  .option('--format <format>', 'Output format: md or json (default: md)', 'md')
+  .action(async (options: { output?: string; format?: string }) => {
     const { reportCommand } = await import('./commands/report.js');
-    await reportCommand();
+    await reportCommand(options);
   });
 
 program
@@ -113,6 +123,90 @@ program
   .action(async (options: { dryRun?: boolean }) => {
     const { fixCommand } = await import('./commands/fix.js');
     await fixCommand(options);
+  });
+
+// Rules subcommands
+const rules = program
+  .command('rules')
+  .description('Manage rules (list, enable, disable)');
+
+rules
+  .command('list')
+  .description('List rules, their severity, and enabled status')
+  .option('--all', 'Include disabled rules')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { all?: boolean; json?: boolean }) => {
+    const { rulesListCommand } = await import('./commands/rules.js');
+    await rulesListCommand(options);
+  });
+
+rules
+  .command('enable <rule>')
+  .description('Enable a specific rule by its ID')
+  .action(async (ruleId: string) => {
+    const { rulesEnableCommand } = await import('./commands/rules.js');
+    await rulesEnableCommand(ruleId);
+  });
+
+rules
+  .command('disable <rule>')
+  .description('Disable a specific rule by its ID')
+  .action(async (ruleId: string) => {
+    const { rulesDisableCommand } = await import('./commands/rules.js');
+    await rulesDisableCommand(ruleId);
+  });
+
+// Presets subcommands
+const presets = program
+  .command('presets')
+  .description('Manage presets (list, add, remove)');
+
+presets
+  .command('list')
+  .description('List available presets and their status')
+  .option('--installed', 'Show only installed presets')
+  .action(async (options: { installed?: boolean }) => {
+    const { presetsListCommand } = await import('./commands/presets.js');
+    await presetsListCommand(options);
+  });
+
+presets
+  .command('add <preset>')
+  .description('Add and activate a preset')
+  .action(async (presetId: string) => {
+    const { presetsAddCommand } = await import('./commands/presets.js');
+    await presetsAddCommand(presetId);
+  });
+
+presets
+  .command('remove <preset>')
+  .description('Remove a preset from the active configuration')
+  .action(async (presetId: string) => {
+    const { presetsRemoveCommand } = await import('./commands/presets.js');
+    await presetsRemoveCommand(presetId);
+  });
+
+// Config subcommands
+const config = program
+  .command('config')
+  .description('View and modify VGuard configuration');
+
+config
+  .command('show')
+  .description('Display the fully resolved configuration')
+  .option('--json', 'Output as JSON')
+  .option('--raw', 'Show raw config without preset resolution')
+  .action(async (options: { json?: boolean; raw?: boolean }) => {
+    const { configShowCommand } = await import('./commands/config.js');
+    await configShowCommand(options);
+  });
+
+config
+  .command('set <key> <value>')
+  .description('Set a configuration option (supports dot-notation for nested keys)')
+  .action(async (key: string, value: string) => {
+    const { configSetCommand } = await import('./commands/config.js');
+    await configSetCommand(key, value);
   });
 
 // Cloud subcommands


### PR DESCRIPTION
## Summary
- Fix `upgrade` command checking for wrong package name (`vguard` instead of `@solanticai/vguard`), causing it to always report "up to date"
- Add `version` subcommand (`vguard version`)
- Add `rules` subcommand group (`rules list [--all] [--json]`, `rules enable <rule>`, `rules disable <rule>`)
- Add `presets` subcommand group (`presets list [--installed]`, `presets add <preset>`, `presets remove <preset>`)
- Add `config` subcommand group (`config show [--json] [--raw]`, `config set <key> <value>`)
- Add `--output <path>` and `--format <md|json>` flags to `report` command
- Bump version to 1.8.1

## Test plan
- [x] `npm run build` passes
- [x] Pre-commit hooks (lint + type-check) pass
- [ ] `vguard version` prints version
- [ ] `vguard upgrade` correctly detects available updates
- [ ] `vguard rules list --all` lists all rules
- [ ] `vguard presets list` lists available presets
- [ ] `vguard config show --json` outputs resolved config
- [ ] `vguard report --output ./test.md` saves report to custom path