### PR TITLE
feat(cli): add --force to init, update release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -200,6 +200,43 @@ If checks fail:
 
 9. Report the discussion URL to the user.
 
+## Step 9: Audit vibe-guard-cloud Documentation
+
+After each release, check whether the cloud documentation needs updates:
+
+1. **Compare rule counts** — Get the total rule count and categories from vibe-guard source:
+   ```bash
+   cd C:/Development/vibe-guard
+   ls src/rules/*/index.ts | wc -l  # Count categories
+   grep -r "registerRule" src/rules/ | wc -l  # Count rules
+   ```
+
+2. **Check docs overview** — Read `C:/Development/vibe-guard-cloud/src/content/docs/rules/overview.md` and verify:
+   - Total rule count matches actual count
+   - All categories are listed
+   - No missing rule category pages
+
+3. **Check for missing doc pages** — Compare rule category directories against doc files:
+   ```bash
+   # Rule categories in source
+   ls C:/Development/vibe-guard/src/rules/
+   # Doc pages that exist
+   ls C:/Development/vibe-guard-cloud/src/content/docs/rules/
+   ```
+   If a category exists in source but has no matching doc page, create one following the format of existing pages.
+
+4. **Check sidebar navigation** — Verify `C:/Development/vibe-guard-cloud/src/app/(public)/docs/layout.tsx` lists all rule category pages in the `NAV_ORDER` Rules section.
+
+5. **Check CLI reference** — If new CLI commands were added, verify `C:/Development/vibe-guard-cloud/src/components/dashboard/CLIReferenceDialog.tsx` includes them.
+
+6. **Commit and push** any docs updates to vibe-guard-cloud:
+   ```bash
+   cd C:/Development/vibe-guard-cloud
+   git add src/content/docs/ src/app/ src/components/
+   git commit -m "docs: update for vX.Y.Z release"
+   git push origin master
+   ```
+
 ## Error Handling
 
 - **Never force-push** or modify master directly

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -20,19 +20,25 @@ import { mergeSettings } from '../../adapters/claude-code/settings-merger.js';
 import { applyProjectIntegrations } from '../../utils/project-scripts.js';
 import { DEFAULT_VGUARDIGNORE } from './init-templates/vguardignore.js';
 
-export async function initCommand(): Promise<void> {
+export async function initCommand(options?: { force?: boolean }): Promise<void> {
   const projectRoot = process.cwd();
 
   console.log('\n  VGuard — AI Coding Guardrails\n');
 
   // Check if already initialized
   if (
-    existsSync(join(projectRoot, 'vguard.config.ts')) ||
-    existsSync(join(projectRoot, '.vguardrc.json'))
+    !options?.force &&
+    (existsSync(join(projectRoot, 'vguard.config.ts')) ||
+      existsSync(join(projectRoot, '.vguardrc.json')))
   ) {
     console.log('  VGuard is already configured in this project.');
-    console.log('  Run `vguard generate` to regenerate hooks.\n');
+    console.log('  Run `vguard generate` to regenerate hooks.');
+    console.log('  Run `vguard init --force` to reconfigure from scratch.\n');
     return;
+  }
+
+  if (options?.force) {
+    console.log('  Reconfiguring VGuard (--force)\n');
   }
 
   // Detect framework

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,9 +24,10 @@ program
 program
   .command('init')
   .description('Interactive setup wizard — configure VGuard for your project')
-  .action(async () => {
+  .option('--force', 'Reconfigure from scratch, overwriting existing config')
+  .action(async (options: { force?: boolean }) => {
     const { initCommand } = await import('./commands/init.js');
-    await initCommand();
+    await initCommand(options);
   });
 
 program


### PR DESCRIPTION
## Summary
- Add `--force` flag to `vguard init` so users can reconfigure from scratch
- Update release skill with Step 9: audit vibe-guard-cloud docs after release

## Test plan
- [ ] `vguard init` still blocks when config exists (without --force)
- [ ] `vguard init --force` reconfigures from scratch
- [ ] Release skill Step 9 instructions are clear and actionable