### PR TITLE
chore(release): v2.0.1 — @anthril/vguard rebrand

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -172,14 +172,14 @@ If checks fail:
 
    ---
 
-   **Full changelog:** https://github.com/Anthril/vibe-guard/blob/master/CHANGELOG.md
+   **Full changelog:** https://github.com/anthril/vibe-guard/blob/master/CHANGELOG.md
    **npm:** https://www.npmjs.com/package/@anthril/vguard/v/X.Y.Z
-   **Release:** https://github.com/Anthril/vibe-guard/releases/tag/vX.Y.Z
+   **Release:** https://github.com/anthril/vibe-guard/releases/tag/vX.Y.Z
    ```
 
 7. Get repository and changelog category IDs:
    ```bash
-   gh api graphql -f query='{ repository(owner: "Anthril", name: "vibe-guard") { id, discussionCategories(first: 20) { nodes { id, name } } } }'
+   gh api graphql -f query='{ repository(owner: "anthril", name: "vibe-guard") { id, discussionCategories(first: 20) { nodes { id, name } } } }'
    ```
 
 8. Create the discussion:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,4 +173,4 @@ export default defineConfig({
 });
 ```
 
-See https://github.com/Anthril/vibe-guard for full documentation.
+See https://github.com/anthril/vibe-guard for full documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ```
   Then run `npx vguard generate` to regenerate hooks with the new import paths.
 - **GitHub org renamed** — all repository URLs, CI badges, sponsor links,
-  and documentation now reference `github.com/Anthril` instead of
+  and documentation now reference `github.com/anthril` instead of
   `github.com/solanticai`.
 - **Author and contact updated** — author field changed from "Solantic Ai"
   to "Anthril". Security reports: `security@anthril.com`. General contact:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-04-12
+
+### Fixed
+
+- **GitHub URLs** — corrected casing in all GitHub URLs from
+  `github.com/Anthril` to `github.com/anthril` to match the
+  canonical GitHub username. Affects README badges, sponsor links,
+  generated hook rule documentation, and release skill templates.
+
 ## [2.0.0] - 2026-04-12
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Development Setup
 
 ```bash
-git clone https://github.com/Anthril/vibe-guard.git
+git clone https://github.com/anthril/vibe-guard.git
 cd vibe-guard
 npm install
 npm run build

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -11,7 +11,7 @@ Everything you need to build, test, and contribute to VGuard.
 ## Setup
 
 ```bash
-git clone https://github.com/Anthril/vibe-guard.git
+git clone https://github.com/anthril/vibe-guard.git
 cd vibe-guard
 npm install
 npm run build

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # =============================================================================
 # VGuard — Contributor Sync
 # =============================================================================
-# Fetches contributor lists from all Anthril repos (vibe-guard,
+# Fetches contributor lists from all anthril repos (vibe-guard,
 # vibe-guard-cloud) via the GitHub CLI, then merges them into a single
 # deduplicated JSON file at .github/data/all-contributors.json.
 #
@@ -12,7 +12,7 @@
 #   make contributors.vibe-guard   Fetch from a single repo
 # =============================================================================
 
-ORG := Anthril
+ORG := anthril
 REPOS := vibe-guard vibe-guard-cloud
 OUT_DIR := .github/data
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 [![npm version](https://img.shields.io/npm/v/@anthril/vguard?color=2563EB&label=npm)](https://www.npmjs.com/package/@anthril/vguard)
 [![npm downloads](https://img.shields.io/npm/dm/@anthril/vguard?color=2563EB)](https://www.npmjs.com/package/@anthril/vguard)
-[![license](https://img.shields.io/github/license/Anthril/vibe-guard?color=2563EB)](LICENSE)
-[![CI](https://img.shields.io/github/actions/workflow/status/Anthril/vibe-guard/ci.yml?label=CI&color=16A34A)](https://github.com/Anthril/vibe-guard/actions)
+[![license](https://img.shields.io/github/license/anthril/vibe-guard?color=2563EB)](LICENSE)
+[![CI](https://img.shields.io/github/actions/workflow/status/anthril/vibe-guard/ci.yml?label=CI&color=16A34A)](https://github.com/anthril/vibe-guard/actions)
 [![node](https://img.shields.io/badge/node-%3E%3D20-16A34A)](package.json)
 
 </div>
@@ -78,9 +78,9 @@ nextjs-15 · react-19 · typescript-strict · supabase · tailwind · django · 
 
 ## Sponsors
 
-This project is maintained by [Anthril](https://github.com/Anthril) and funded by our sponsors.
+This project is maintained by [Anthril](https://github.com/anthril) and funded by our sponsors.
 
-[Become a sponsor →](https://github.com/sponsors/Anthril)
+[Become a sponsor →](https://github.com/sponsors/anthril)
 
 ### Featured Sponsors
 
@@ -92,7 +92,7 @@ This project is maintained by [Anthril](https://github.com/Anthril) and funded b
 
 ## Community
 
-- [GitHub Discussions](https://github.com/Anthril/vibe-guard/discussions)
+- [GitHub Discussions](https://github.com/anthril/vibe-guard/discussions)
 - [Contributing](CONTRIBUTING.md)
 - [Code of Conduct](CODE_OF_CONDUCT.md)
 - [Security Policy](SECURITY.md)

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,8 +1,8 @@
 # Sponsors
 
-Thank you to everyone who sponsors [Anthril](https://github.com/Anthril)'s open-source work. Your support directly funds development and maintenance of this project and our wider ecosystem.
+Thank you to everyone who sponsors [Anthril](https://github.com/anthril)'s open-source work. Your support directly funds development and maintenance of this project and our wider ecosystem.
 
-[Become a sponsor →](https://github.com/sponsors/Anthril)
+[Become a sponsor →](https://github.com/sponsors/anthril)
 
 ---
 
@@ -28,4 +28,4 @@ Thank you to everyone who sponsors [Anthril](https://github.com/Anthril)'s open-
 
 ---
 
-_This file is automatically updated by [GitHub Actions](https://github.com/Anthril/.github/actions). To sponsor, visit [github.com/sponsors/Anthril](https://github.com/sponsors/Anthril)._
+_This file is automatically updated by [GitHub Actions](https://github.com/anthril/.github/actions). To sponsor, visit [github.com/sponsors/anthril](https://github.com/sponsors/anthril)._

--- a/ai-for-vibe-guard/README.md
+++ b/ai-for-vibe-guard/README.md
@@ -1,13 +1,13 @@
 # AI Skills for VGuard
 
-This directory contains AI-readable skill definitions that help AI coding assistants set up, configure, and troubleshoot [VGuard](https://github.com/Anthril/vibe-guard) — the open-source AI coding guardrails framework.
+This directory contains AI-readable skill definitions that help AI coding assistants set up, configure, and troubleshoot [VGuard](https://github.com/anthril/vibe-guard) — the open-source AI coding guardrails framework.
 
 ## How to Use
 
 Point your AI assistant at the relevant skill file:
 
 ```
-Read and follow: https://github.com/Anthril/vibe-guard/blob/master/ai-for-vibe-guard/skills/setup-vguard/SKILL.md
+Read and follow: https://github.com/anthril/vibe-guard/blob/master/ai-for-vibe-guard/skills/setup-vguard/SKILL.md
 ```
 
 Or reference the local path if you have the repo cloned.
@@ -37,5 +37,5 @@ VGuard enforces code quality guardrails when AI coding agents (Claude Code, Curs
 
 - [npm package](https://www.npmjs.com/package/@anthril/vguard)
 - [Documentation](https://vguard.dev/docs)
-- [GitHub](https://github.com/Anthril/vibe-guard)
+- [GitHub](https://github.com/anthril/vibe-guard)
 - [VGuard Cloud](https://vguard.dev)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthril/vguard",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthril/vguard",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -58,10 +58,10 @@
   "homepage": "https://vguard.dev",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Anthril/vibe-guard.git"
+    "url": "git+https://github.com/anthril/vibe-guard.git"
   },
   "bugs": {
-    "url": "https://github.com/Anthril/vibe-guard/issues"
+    "url": "https://github.com/anthril/vibe-guard/issues"
   },
   "publishConfig": {
     "access": "public",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthril/vguard",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "AI coding guardrails framework. Runtime-enforced quality controls for Claude Code, Cursor, Codex, and more.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/adapters/claude-code/templates/rules-template.ts
+++ b/src/adapters/claude-code/templates/rules-template.ts
@@ -43,7 +43,7 @@ export function buildEnforcementRulesMarkdown(config: ResolvedConfig): string {
     '',
     '# VGuard Enforcement Rules',
     '',
-    `This project uses [VGuard](https://github.com/Anthril/vibe-guard) for AI coding guardrails.`,
+    `This project uses [VGuard](https://github.com/anthril/vibe-guard) for AI coding guardrails.`,
     `**${totalCount} rules** are actively enforced via runtime hooks.`,
     '',
   ];


### PR DESCRIPTION
## Release v2.0.0 + v2.0.1

### v2.0.0 — Breaking: npm scope rename
- Package renamed from `@solanticai/vguard` to `@anthril/vguard`
- All source, docs, CI, tests, and generated hooks updated
- Deprecated `learn.ignorePaths` and `cloud.excludePaths` removed

### v2.0.1 — Patch: URL casing fix
- Corrected `github.com/Anthril` to `github.com/anthril` across all files

### Commits
- `c8345bf` chore(release): bump version to 2.0.1
- `43c00da` fix: lowercase github org in all URLs
- `83fd89a` style: fix prettier formatting in troubleshoot skill
- `58edd58` chore(release)!: rename to @anthril/vguard and bump to v2.0.0

### Checklist
- [x] Both versions already published to npm
- [x] All 998 tests passing
- [x] CI passing on previous push