### PR TITLE
fix(learn): walker skips symlinks to close arbitrary-file-read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Walker no longer follows symlinks.** `walkProject()` in
+  `src/learn/walker.ts` now uses `lstatSync` and skips any entry whose
+  `isSymbolicLink()` is true, closing an arbitrary-file-read path on
+  shared dev hosts and CI agents where a symlink inside the project
+  tree (e.g. `./spicy.txt -> ~/.ssh/id_rsa`) would previously be read
+  into `learn`/`lint` processing context and could be forwarded to
+  cloud sync. Following symlinks can be re-enabled per project in the
+  future behind an explicit opt-in, but the default is now "never".
+  Fixes #46.
+
 ### Added
 
 - **`sweep-gitignore` skill** under `ai-for-vibe-guard/skills/`.

--- a/src/learn/walker.ts
+++ b/src/learn/walker.ts
@@ -1,4 +1,4 @@
-import { readdirSync, statSync, readFileSync } from 'node:fs';
+import { readdirSync, lstatSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { normalizePath } from '../utils/path.js';
 import { createIgnoreMatcher, type IgnoreMatcher } from '../utils/ignore.js';
@@ -69,7 +69,8 @@ function walkDir(dir: string, matcher: IgnoreMatcher, files: WalkedFile[], maxFi
     const fullPath = join(dir, entry);
 
     try {
-      const stat = statSync(fullPath);
+      const stat = lstatSync(fullPath);
+      if (stat.isSymbolicLink()) continue;
       if (stat.isDirectory()) {
         if (matcher.isIgnored(fullPath + '/')) continue;
         walkDir(fullPath, matcher, files, maxFiles);

--- a/tests/learn/walker.test.ts
+++ b/tests/learn/walker.test.ts
@@ -16,34 +16,42 @@ vi.mock('node:fs', async () => {
   const dist = pathJoin('/project', 'dist');
   const readme = pathJoin('/project', 'README.md');
   const image = pathJoin('/project', 'image.png');
+  const symlinkFile = pathJoin('/project', 'src', 'spicy.ts');
+  const symlinkDir = pathJoin('/project', 'linked-dir');
 
-  const files: Record<string, { content: string; isDir: boolean; size: number }> = {
-    [root]: { content: '', isDir: true, size: 0 },
-    [src]: { content: '', isDir: true, size: 0 },
-    [indexTs]: { content: 'export const x = 1;', isDir: false, size: 20 },
-    [appTsx]: { content: '<App />', isDir: false, size: 10 },
-    [utilsJs]: { content: 'module.exports = {};', isDir: false, size: 25 },
-    [nodeModules]: { content: '', isDir: true, size: 0 },
-    [dist]: { content: '', isDir: true, size: 0 },
-    [readme]: { content: '# README', isDir: false, size: 10 },
-    [image]: { content: '', isDir: false, size: 100 },
+  const files: Record<
+    string,
+    { content: string; isDir: boolean; isSymlink: boolean; size: number }
+  > = {
+    [root]: { content: '', isDir: true, isSymlink: false, size: 0 },
+    [src]: { content: '', isDir: true, isSymlink: false, size: 0 },
+    [indexTs]: { content: 'export const x = 1;', isDir: false, isSymlink: false, size: 20 },
+    [appTsx]: { content: '<App />', isDir: false, isSymlink: false, size: 10 },
+    [utilsJs]: { content: 'module.exports = {};', isDir: false, isSymlink: false, size: 25 },
+    [nodeModules]: { content: '', isDir: true, isSymlink: false, size: 0 },
+    [dist]: { content: '', isDir: true, isSymlink: false, size: 0 },
+    [readme]: { content: '# README', isDir: false, isSymlink: false, size: 10 },
+    [image]: { content: '', isDir: false, isSymlink: false, size: 100 },
+    [symlinkFile]: { content: 'SECRET', isDir: false, isSymlink: true, size: 20 },
+    [symlinkDir]: { content: '', isDir: true, isSymlink: true, size: 0 },
   };
 
   const dirEntries: Record<string, string[]> = {
-    [root]: ['src', 'node_modules', 'dist', 'README.md', 'image.png'],
-    [src]: ['index.ts', 'app.tsx', 'utils.js'],
+    [root]: ['src', 'node_modules', 'dist', 'README.md', 'image.png', 'linked-dir'],
+    [src]: ['index.ts', 'app.tsx', 'utils.js', 'spicy.ts'],
   };
 
   return {
     readdirSync: vi.fn((dir: string) => {
       return dirEntries[dir] ?? [];
     }),
-    statSync: vi.fn((path: string) => {
+    lstatSync: vi.fn((path: string) => {
       const entry = files[path];
       if (!entry) throw new Error(`ENOENT: ${path}`);
       return {
         isDirectory: () => entry.isDir,
         isFile: () => !entry.isDir,
+        isSymbolicLink: () => entry.isSymlink,
         size: entry.size,
       };
     }),
@@ -96,5 +104,12 @@ describe('File System Walker', () => {
       expect(file.directory).toBeTruthy();
       expect(file.path).toBeTruthy();
     }
+  });
+
+  it('skips symbolic links (files and directories)', () => {
+    const files = walkProject({ rootDir: ROOT });
+    const paths = files.map((f) => f.path);
+    expect(paths.every((p) => !p.includes('spicy.ts'))).toBe(true);
+    expect(paths.every((p) => !p.includes('linked-dir'))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Closes #46.

`walkProject()` in `src/learn/walker.ts` used `statSync`, which transparently followed symlinks. On shared dev hosts or CI agents, any user who could create a symlink inside the project tree (e.g. `./spicy.txt -> ~/.ssh/id_rsa`) could have linked content read into `learn` / `lint` processing context — and, when cloud sync is enabled, forwarded to the remote in rule messages and metadata. That turned the walker into a sandbox-escape from the implicit "vguard operates on repo files only" contract.

This PR switches to `lstatSync` and skips any entry whose `isSymbolicLink()` is true. Following symlinks will remain unavailable until an explicit opt-in is designed; secure default first.

## Changes

- `src/learn/walker.ts` — `statSync` → `lstatSync`; early `continue` on symlinks.
- `tests/learn/walker.test.ts` — extended `node:fs` mock with `isSymbolicLink()` and added coverage for both symlinked files and symlinked directories.
- `CHANGELOG.md` — entry under `[Unreleased] > Security`.

## Test plan

- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm test` — all 1422 tests pass (+1 new case)
- [ ] Manual repro on POSIX: `ln -s ~/.ssh/id_rsa ./spicy.txt && npx vguard learn` — walker no longer reads the linked content

🤖 Generated with [Claude Code](https://claude.com/claude-code)