### PR TITLE
fix(cloud): allowlist cloud URLs to prevent MITM / data exfil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cloud sync. Following symlinks can be re-enabled per project in the
   future behind an explicit opt-in, but the default is now "never".
   Fixes #46.
+- **Cloud URLs now pass through an allowlist guard.** `src/cloud/url-guard.ts`
+  exports `assertSafeCloudUrl()` / `sanitiseBaseUrl()`, which require
+  `https://`, reject `user:pass@` userinfo, and accept only
+  `vguard.dev`, `api.vguard.dev`, and `*.supabase.co` hosts by default.
+  Applied at every outbound dial site: `CloudClient` base URL, config push
+  to the Edge Function host, the rule-hit streamer, the session-event
+  streamer, the OAuth refresh path in `credentials.ts`, and both branches
+  of `vguard cloud login`. A modified `~/.vguard/credentials.json` or
+  hostile `VGUARD_CLOUD_URL` env var can no longer redirect refresh
+  tokens, access tokens, or rule-hit payloads (which may contain source
+  excerpts) to an attacker-controlled server. Local development against
+  `localhost` / private IP ranges is still available behind an explicit
+  `VGUARD_DEV=1`. Fixes #48.
 
 ### Added
 

--- a/src/cli/commands/cloud-login.ts
+++ b/src/cli/commands/cloud-login.ts
@@ -2,6 +2,7 @@ import http from 'node:http';
 import crypto from 'node:crypto';
 import { execFile } from 'node:child_process';
 import { readCredentials, writeCredentials, getCredentialsPath } from '../../cloud/credentials.js';
+import { assertSafeCloudUrl } from '../../cloud/url-guard.js';
 import { printBanner } from '../ui/banner.js';
 import { color } from '../ui/colors.js';
 import { glyph } from '../ui/glyphs.js';
@@ -43,6 +44,14 @@ export async function cloudLoginCommand(
   const cloudUrl = options.url ?? existingCreds?.apiUrl ?? DEFAULT_CLOUD_URL;
   const supabaseUrl = options.supabaseUrl ?? existingCreds?.supabaseUrl ?? DEFAULT_SUPABASE_URL;
   const clientId = DEFAULT_OAUTH_CLIENT_ID;
+
+  try {
+    assertSafeCloudUrl(cloudUrl);
+    assertSafeCloudUrl(supabaseUrl);
+  } catch (err) {
+    error(err instanceof Error ? err.message : 'Invalid cloud URL');
+    process.exit(EXIT.USAGE);
+  }
 
   if (options.noInteractive) {
     info('  To authenticate, visit:');
@@ -98,6 +107,14 @@ function handleTokenLogin(options: {
   supabaseUrl?: string;
   supabaseAnonKey?: string;
 }): void {
+  try {
+    if (options.url) assertSafeCloudUrl(options.url);
+    if (options.supabaseUrl) assertSafeCloudUrl(options.supabaseUrl);
+  } catch (err) {
+    error(err instanceof Error ? err.message : 'Invalid cloud URL');
+    process.exit(EXIT.USAGE);
+  }
+
   let expiresAt: string | undefined;
   let email: string | undefined;
   try {

--- a/src/cloud/client.ts
+++ b/src/cloud/client.ts
@@ -1,4 +1,5 @@
 import { readCredentials, getValidCredentials } from './credentials.js';
+import { sanitiseBaseUrl } from './url-guard.js';
 import type { ProjectConfigPushPayload } from '../types.js';
 
 const DEFAULT_API_URL = process.env.VGUARD_CLOUD_URL ?? 'https://vguard.dev';
@@ -33,7 +34,7 @@ export class CloudClient {
   constructor(options: CloudClientOptions = {}) {
     const creds = readCredentials();
     const url = options.apiUrl ?? creds?.apiUrl ?? DEFAULT_API_URL;
-    this.apiUrl = url.replace(/\/$/, '');
+    this.apiUrl = sanitiseBaseUrl(url);
     this.apiKey = options.apiKey;
   }
 
@@ -51,7 +52,7 @@ export class CloudClient {
     payload: ProjectConfigPushPayload,
     timeoutMs = 5_000,
   ): Promise<{ updated: boolean; projectId: string }> {
-    const url = DEFAULT_FUNCTIONS_URL.replace(/\/$/, '') + '/functions/v1/ingest-config';
+    const url = sanitiseBaseUrl(DEFAULT_FUNCTIONS_URL) + '/functions/v1/ingest-config';
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {

--- a/src/cloud/credentials.ts
+++ b/src/cloud/credentials.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { sanitiseBaseUrl } from './url-guard.js';
 
 const CREDENTIALS_DIR = join(homedir(), '.vguard');
 const CREDENTIALS_FILE = join(CREDENTIALS_DIR, 'credentials.json');
@@ -94,9 +95,18 @@ export async function refreshAccessToken(): Promise<CloudCredentials | null> {
   // OAuth client ID — needed for public client refresh per OAuth 2.1 spec
   const clientId = process.env.VGUARD_OAUTH_CLIENT_ID ?? 'd49f2c6e-473a-4b94-acdf-9f282cc9a278';
 
+  let refreshBase: string;
+  try {
+    refreshBase = sanitiseBaseUrl(creds.supabaseUrl);
+  } catch {
+    // Malformed / non-allowlisted supabaseUrl — refuse to refresh rather than
+    // leak the refresh token to an attacker-controlled host.
+    return null;
+  }
+
   try {
     // Use the OAuth token endpoint for refresh (per Supabase OAuth 2.1 docs)
-    const res = await fetch(`${creds.supabaseUrl}/auth/v1/oauth/token`, {
+    const res = await fetch(`${refreshBase}/auth/v1/oauth/token`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: new URLSearchParams({

--- a/src/cloud/session-streamer.ts
+++ b/src/cloud/session-streamer.ts
@@ -14,6 +14,7 @@ import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from '
 import { dirname, join } from 'node:path';
 
 import type { SessionEventRecord } from '../engine/session-tracker.js';
+import { sanitiseBaseUrl } from './url-guard.js';
 
 const EVENTS_FILE = '.vguard/data/session-events.jsonl';
 const CURSOR_FILE = '.vguard/data/session-events.cursor.json';
@@ -105,7 +106,7 @@ export async function flushSessionEvents(
     try {
       const body = pending.map((e) => JSON.stringify(e)).join('\n');
       const url =
-        (process.env.VGUARD_CLOUD_URL ?? 'https://vguard.dev').replace(/\/$/, '') +
+        sanitiseBaseUrl(process.env.VGUARD_CLOUD_URL ?? 'https://vguard.dev') +
         '/api/v1/sessions/events';
 
       const res = await fetch(url, {

--- a/src/cloud/streamer.ts
+++ b/src/cloud/streamer.ts
@@ -3,6 +3,7 @@ import { join, dirname } from 'node:path';
 import type { CloudConfig } from '../types.js';
 import { readRuleHits } from '../engine/tracker.js';
 import { readSyncCursor, writeSyncCursor, getUnsyncedRecords, applyExclusions } from './sync.js';
+import { sanitiseBaseUrl } from './url-guard.js';
 
 const FLUSH_STATE_FILE = '.vguard/data/flush-state.json';
 
@@ -159,8 +160,7 @@ export async function maybeFlushToCloud(
     try {
       const body = batch.map((r) => JSON.stringify(r)).join('\n');
       const url =
-        (process.env.VGUARD_CLOUD_URL ?? 'https://vguard.dev').replace(/\/$/, '') +
-        '/api/v1/ingest';
+        sanitiseBaseUrl(process.env.VGUARD_CLOUD_URL ?? 'https://vguard.dev') + '/api/v1/ingest';
 
       const res = await fetch(url, {
         method: 'POST',

--- a/src/cloud/url-guard.ts
+++ b/src/cloud/url-guard.ts
@@ -1,0 +1,75 @@
+/**
+ * Safeguards for URLs that VGuard's cloud layer dials out to.
+ *
+ * Every URL read from credentials, environment variables, or config runs
+ * through `assertSafeCloudUrl`. Relaxing this guard — e.g. adding a new
+ * allowlisted host — is a deliberate security decision, not a convenience
+ * knob, because rule-hit payloads can contain source-file excerpts and
+ * exfiltration via a hijacked endpoint would ship both credentials and code.
+ */
+
+const ALLOWED_HOSTS = new Set<string>(['vguard.dev', 'api.vguard.dev']);
+const ALLOWED_HOST_SUFFIXES = ['.supabase.co'];
+
+const PRIVATE_IPV4_PREFIXES = ['10.', '127.', '192.168.'];
+function isPrivateHost(host: string): boolean {
+  if (host === 'localhost' || host === '::1') return true;
+  if (PRIVATE_IPV4_PREFIXES.some((p) => host.startsWith(p))) return true;
+  if (/^172\.(1[6-9]|2\d|3[0-1])\./.test(host)) return true;
+  return false;
+}
+
+function isDevMode(): boolean {
+  return process.env.VGUARD_DEV === '1';
+}
+
+/**
+ * Parse `raw` as a URL and confirm it is safe to dial out to.
+ *
+ * Rules:
+ *   1. Must parse.
+ *   2. Must use `https:` — or `http:` with a private host under `VGUARD_DEV=1`.
+ *   3. No `user:pass@` userinfo segment (can mask the real host in UIs and logs).
+ *   4. Host is in the allowlist, ends with `.supabase.co`, or is private under
+ *      `VGUARD_DEV=1`.
+ */
+export function assertSafeCloudUrl(raw: string): URL {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(`Invalid cloud URL: ${raw}`);
+  }
+
+  if (url.username || url.password) {
+    throw new Error(`Cloud URL must not contain userinfo: ${url.origin}`);
+  }
+
+  const host = url.hostname.toLowerCase();
+  const allowedByList =
+    ALLOWED_HOSTS.has(host) || ALLOWED_HOST_SUFFIXES.some((s) => host.endsWith(s));
+  const allowedAsPrivate = isDevMode() && isPrivateHost(host);
+
+  if (!allowedByList && !allowedAsPrivate) {
+    throw new Error(
+      `Cloud URL host '${host}' is not allowlisted. ` +
+        `Expected one of: ${[...ALLOWED_HOSTS].join(', ')}, or any *.supabase.co host.`,
+    );
+  }
+
+  if (url.protocol === 'https:') return url;
+  if (url.protocol === 'http:' && allowedAsPrivate) return url;
+
+  throw new Error(
+    `Cloud URL must use https:// (got ${url.protocol}//${host}). ` +
+      `Set VGUARD_DEV=1 to allow http:// against private hosts for local development.`,
+  );
+}
+
+/**
+ * Normalise `raw` for use as a base URL: validate + strip trailing slash.
+ */
+export function sanitiseBaseUrl(raw: string): string {
+  const url = assertSafeCloudUrl(raw);
+  return url.toString().replace(/\/$/, '');
+}

--- a/tests/cloud/url-guard.test.ts
+++ b/tests/cloud/url-guard.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { assertSafeCloudUrl, sanitiseBaseUrl } from '../../src/cloud/url-guard.js';
+
+describe('assertSafeCloudUrl', () => {
+  const originalEnv = process.env.VGUARD_DEV;
+
+  beforeEach(() => {
+    delete process.env.VGUARD_DEV;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.VGUARD_DEV;
+    } else {
+      process.env.VGUARD_DEV = originalEnv;
+    }
+  });
+
+  describe('allowed hosts', () => {
+    it('accepts https://vguard.dev', () => {
+      expect(() => assertSafeCloudUrl('https://vguard.dev')).not.toThrow();
+    });
+
+    it('accepts https://api.vguard.dev', () => {
+      expect(() => assertSafeCloudUrl('https://api.vguard.dev')).not.toThrow();
+    });
+
+    it('accepts *.supabase.co hosts', () => {
+      expect(() => assertSafeCloudUrl('https://mpisrdadthdhpvgimtzv.supabase.co')).not.toThrow();
+      expect(() => assertSafeCloudUrl('https://other.supabase.co')).not.toThrow();
+    });
+
+    it('is case insensitive on host', () => {
+      expect(() => assertSafeCloudUrl('https://VGUARD.DEV')).not.toThrow();
+    });
+  });
+
+  describe('scheme enforcement', () => {
+    it('rejects http:// on allowlisted hosts', () => {
+      expect(() => assertSafeCloudUrl('http://vguard.dev')).toThrow(/must use https/);
+    });
+
+    it('rejects ftp://', () => {
+      expect(() => assertSafeCloudUrl('ftp://vguard.dev')).toThrow(/must use https/);
+    });
+
+    it('rejects javascript: URLs', () => {
+      expect(() => assertSafeCloudUrl('javascript:alert(1)')).toThrow();
+    });
+  });
+
+  describe('userinfo', () => {
+    it('rejects user:pass@ in URL', () => {
+      expect(() => assertSafeCloudUrl('https://user:pass@vguard.dev')).toThrow(/userinfo/);
+    });
+
+    it('rejects bare user@ in URL', () => {
+      expect(() => assertSafeCloudUrl('https://user@vguard.dev')).toThrow(/userinfo/);
+    });
+  });
+
+  describe('foreign hosts', () => {
+    it('rejects arbitrary external hosts', () => {
+      expect(() => assertSafeCloudUrl('https://evil.example.com')).toThrow(/not allowlisted/);
+    });
+
+    it('rejects hosts that only contain supabase.co as a substring', () => {
+      expect(() => assertSafeCloudUrl('https://supabase.co.evil.com')).toThrow(/not allowlisted/);
+    });
+
+    it('rejects malformed URLs', () => {
+      expect(() => assertSafeCloudUrl('not a url')).toThrow(/Invalid cloud URL/);
+    });
+  });
+
+  describe('VGUARD_DEV escape hatch', () => {
+    it('rejects localhost without VGUARD_DEV', () => {
+      expect(() => assertSafeCloudUrl('http://localhost:3000')).toThrow(/not allowlisted/);
+    });
+
+    it('accepts http://localhost:3000 with VGUARD_DEV=1', () => {
+      process.env.VGUARD_DEV = '1';
+      expect(() => assertSafeCloudUrl('http://localhost:3000')).not.toThrow();
+    });
+
+    it('accepts http://127.0.0.1 with VGUARD_DEV=1', () => {
+      process.env.VGUARD_DEV = '1';
+      expect(() => assertSafeCloudUrl('http://127.0.0.1:8000')).not.toThrow();
+    });
+
+    it('accepts http://192.168.1.5 with VGUARD_DEV=1', () => {
+      process.env.VGUARD_DEV = '1';
+      expect(() => assertSafeCloudUrl('http://192.168.1.5')).not.toThrow();
+    });
+
+    it('accepts https://localhost with VGUARD_DEV=1', () => {
+      process.env.VGUARD_DEV = '1';
+      expect(() => assertSafeCloudUrl('https://localhost')).not.toThrow();
+    });
+
+    it('does not grant access to foreign hosts even with VGUARD_DEV=1', () => {
+      process.env.VGUARD_DEV = '1';
+      expect(() => assertSafeCloudUrl('https://evil.example.com')).toThrow(/not allowlisted/);
+    });
+  });
+});
+
+describe('sanitiseBaseUrl', () => {
+  it('returns URL without trailing slash', () => {
+    expect(sanitiseBaseUrl('https://vguard.dev/')).toBe('https://vguard.dev');
+  });
+
+  it('preserves URL without trailing slash', () => {
+    expect(sanitiseBaseUrl('https://vguard.dev')).toBe('https://vguard.dev');
+  });
+
+  it('throws on disallowed URLs', () => {
+    expect(() => sanitiseBaseUrl('https://evil.example.com')).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #48.

Cloud-bound URLs were built directly from `~/.vguard/credentials.json` and `VGUARD_CLOUD_URL` / `VGUARD_FUNCTIONS_URL` env vars, then passed straight to `fetch()`. Anyone who could modify those (compromised credentials file, malicious CI env, a phishing link that led a user to run `cloud login --url ...`) could redirect OAuth refresh/access tokens and rule-hit NDJSON payloads — which may contain source excerpts in the `message` field — to an attacker-controlled host.

New `src/cloud/url-guard.ts` exposes `assertSafeCloudUrl` / `sanitiseBaseUrl`, wired into every outbound dial site.

## Guard rules

1. `https://` only — or `http://` against private hosts under `VGUARD_DEV=1`.
2. No `user:pass@` userinfo segment.
3. Host ∈ {`vguard.dev`, `api.vguard.dev`} or ends with `.supabase.co`. Private IPv4/IPv6/`localhost` allowed under `VGUARD_DEV=1` only.

## Sites threaded

- `CloudClient` constructor + `pushConfigSnapshot`
- `streamer.ts` rule-hit flush
- `session-streamer.ts` lifecycle flush
- `credentials.ts` OAuth refresh — refuses to ship refresh tokens to a non-allowlisted host
- `cloud-login.ts` — validates both `--url` and `--supabase-url` in interactive and token flows

## Test plan

- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm test` — 1442 tests pass (+21 new)
- [x] Added 21 unit tests covering allowed hosts, scheme enforcement, userinfo rejection, foreign-host rejection, lookalike hosts (`supabase.co.evil.com` stays blocked), and the full `VGUARD_DEV` escape-hatch matrix
- [ ] Manual: `VGUARD_CLOUD_URL=https://evil.example.com npx vguard cloud login` fails fast with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)