### PR TITLE
fix(cli): rules list uses resolved severity, not catalogue default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`vguard rules list` now reports the resolved severity for
+  config-overridden rules.** The command used to emit the catalogue
+  default (`rule.severity`) in both the human-readable table and the
+  `--json` output, silently contradicting `config show` and the
+  adapter-generated enforcement docs for any rule whose severity was
+  overridden in `vguard.config.ts`. CI scripts that grepped
+  `rules list --json` for blocking rules got wrong answers on any
+  preset + user override combination. Now the command threads every
+  rule through `resolved.rules` (the same source `config show` uses)
+  and falls back to the catalogue default only when the config is
+  unreadable. Fixes #45.
+
 - `rollingWindowSpend(root, 0)` and the underlying `readUsage` filter
   now use strict `>` instead of `>=` for the `sinceIso` cutoff, so a
   zero-width window returns zero records deterministically (fixes a

--- a/src/cli/commands/rules.ts
+++ b/src/cli/commands/rules.ts
@@ -21,17 +21,24 @@ export async function rulesListCommand(options: { all?: boolean; json?: boolean 
   const allRules = getAllRules();
 
   const discovered = discoverConfigFile(projectRoot);
-  let enabledRuleIds = new Set<string>();
+  // `resolved.rules` holds the final severity after preset + user merging.
+  // Use it as the source of truth so `rules list` matches `config show` and
+  // the adapter-generated enforcement docs. Falling back to the catalogue
+  // severity on config errors keeps the listing useful when the config is
+  // broken.
+  let resolvedRules: Map<string, { enabled: boolean; severity: 'block' | 'warn' | 'info' }> =
+    new Map();
 
   if (discovered) {
     try {
       const rawConfig = (await readRawConfig(discovered)) as VGuardConfig;
       const presetMap = getAllPresets();
       const resolved = resolveConfig(rawConfig, presetMap);
-      enabledRuleIds = new Set(
-        Array.from(resolved.rules.entries())
-          .filter(([, cfg]) => cfg.enabled)
-          .map(([id]) => id),
+      resolvedRules = new Map(
+        Array.from(resolved.rules.entries()).map(([id, cfg]) => [
+          id,
+          { enabled: cfg.enabled, severity: cfg.severity },
+        ]),
       );
     } catch {
       // Config errors are non-fatal for listing
@@ -39,13 +46,16 @@ export async function rulesListCommand(options: { all?: boolean; json?: boolean 
   }
 
   const rules = Array.from(allRules.entries())
-    .map(([id, rule]) => ({
-      id,
-      name: rule.name,
-      severity: rule.severity,
-      enabled: enabledRuleIds.has(id),
-      description: rule.description,
-    }))
+    .map(([id, rule]) => {
+      const res = resolvedRules.get(id);
+      return {
+        id,
+        name: rule.name,
+        severity: res?.severity ?? rule.severity,
+        enabled: res?.enabled ?? false,
+        description: rule.description,
+      };
+    })
     .filter((r) => options.all || r.enabled)
     .sort((a, b) => a.id.localeCompare(b.id));
 

--- a/tests/cli/rules-list.test.ts
+++ b/tests/cli/rules-list.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Rule, VGuardConfig, ResolvedConfig, Preset } from '../../src/types.js';
+
+vi.mock('../../src/presets/index.js', () => ({}));
+vi.mock('../../src/rules/index.js', () => ({}));
+
+vi.mock('../../src/engine/registry.js', () => ({
+  getAllRules: vi.fn(),
+}));
+
+vi.mock('../../src/config/discovery.js', () => ({
+  discoverConfigFile: vi.fn(),
+  readRawConfig: vi.fn(),
+}));
+
+vi.mock('../../src/config/loader.js', () => ({
+  resolveConfig: vi.fn(),
+}));
+
+vi.mock('../../src/config/presets.js', () => ({
+  getAllPresets: vi.fn(() => new Map<string, Preset>()),
+}));
+
+vi.mock('../../src/cli/ui/banner.js', () => ({
+  printBanner: vi.fn(),
+}));
+
+vi.mock('../../src/cli/ui/log.js', () => ({
+  error: vi.fn(),
+  info: vi.fn(),
+}));
+
+import { getAllRules } from '../../src/engine/registry.js';
+import { discoverConfigFile, readRawConfig } from '../../src/config/discovery.js';
+import { resolveConfig } from '../../src/config/loader.js';
+import { rulesListCommand } from '../../src/cli/commands/rules.js';
+
+function makeRule(overrides: Partial<Rule>): Rule {
+  return {
+    id: overrides.id ?? 'security/example',
+    name: overrides.name ?? 'Example',
+    description: overrides.description ?? 'desc',
+    severity: overrides.severity ?? 'warn',
+    events: overrides.events ?? ['PreToolUse'],
+    match: overrides.match ?? {},
+    check:
+      overrides.check ?? (() => ({ status: 'pass', ruleId: overrides.id ?? 'security/example' })),
+  };
+}
+
+describe('rulesListCommand --json', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true) as ReturnType<
+      typeof vi.spyOn
+    >;
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+  });
+
+  it('reports resolved severity when the config overrides the catalogue default', async () => {
+    const rule = makeRule({
+      id: 'security/package-typosquat-guard',
+      severity: 'warn', // catalogue default
+    });
+
+    vi.mocked(getAllRules).mockReturnValue(new Map([[rule.id, rule]]));
+    vi.mocked(discoverConfigFile).mockReturnValue('/project/vguard.config.ts');
+    vi.mocked(readRawConfig).mockResolvedValue({} as VGuardConfig);
+    vi.mocked(resolveConfig).mockReturnValue({
+      presets: [],
+      agents: ['claude-code'],
+      rules: new Map([[rule.id, { enabled: true, severity: 'block', options: {} }]]),
+    } as ResolvedConfig);
+
+    await rulesListCommand({ json: true, all: true });
+
+    const written = stdoutSpy.mock.calls.map((c) => c[0]).join('');
+    const parsed = JSON.parse(written) as Array<{
+      id: string;
+      severity: string;
+      enabled: boolean;
+    }>;
+
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].id).toBe(rule.id);
+    // Must be the resolved severity, not the catalogue default.
+    expect(parsed[0].severity).toBe('block');
+    expect(parsed[0].enabled).toBe(true);
+  });
+
+  it('falls back to catalogue severity when the rule is not in the resolved config', async () => {
+    const rule = makeRule({ id: 'quality/example', severity: 'info' });
+
+    vi.mocked(getAllRules).mockReturnValue(new Map([[rule.id, rule]]));
+    vi.mocked(discoverConfigFile).mockReturnValue('/project/vguard.config.ts');
+    vi.mocked(readRawConfig).mockResolvedValue({} as VGuardConfig);
+    vi.mocked(resolveConfig).mockReturnValue({
+      presets: [],
+      agents: ['claude-code'],
+      rules: new Map(),
+    } as ResolvedConfig);
+
+    await rulesListCommand({ json: true, all: true });
+
+    const written = stdoutSpy.mock.calls.map((c) => c[0]).join('');
+    const parsed = JSON.parse(written) as Array<{
+      severity: string;
+      enabled: boolean;
+    }>;
+
+    expect(parsed[0].severity).toBe('info');
+    expect(parsed[0].enabled).toBe(false);
+  });
+
+  it('falls back to catalogue severity when resolveConfig throws', async () => {
+    const rule = makeRule({ id: 'security/foo', severity: 'warn' });
+
+    vi.mocked(getAllRules).mockReturnValue(new Map([[rule.id, rule]]));
+    vi.mocked(discoverConfigFile).mockReturnValue('/project/vguard.config.ts');
+    vi.mocked(readRawConfig).mockRejectedValue(new Error('bad config'));
+
+    await rulesListCommand({ json: true, all: true });
+
+    const written = stdoutSpy.mock.calls.map((c) => c[0]).join('');
+    const parsed = JSON.parse(written) as Array<{ severity: string; enabled: boolean }>;
+    expect(parsed[0].severity).toBe('warn');
+    expect(parsed[0].enabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #45.

`rules list` and `rules list --json` iterated the built-in rule catalogue and emitted `rule.severity` — the pre-merge default baked into the rule module. For any rule whose severity was overridden in `vguard.config.ts` (directly or via a preset downgrade), the command silently contradicted `config show`, adapter-generated enforcement docs, and runtime enforcement — all of which were correct.

CI scripts that filtered `rules list --json | jq '.[] | select(.severity==\"block\")'` got silently-wrong answers on any project with preset or user severity overrides.

## Fix

`rulesListCommand` already called `resolveConfig()` to compute the enabled set — it just threw away the resolved severity. Thread the resolved entry through instead. Fall back to the catalogue default only when the config is unreadable, so a broken config still produces a useful listing.

## Test plan

- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm test` — 1424 tests pass (+3 new in `tests/cli/rules-list.test.ts`)
- [x] Override propagates to `--json` output (issue repro case)
- [x] Rule absent from resolved config falls back to catalogue default
- [x] `readRawConfig` throwing falls back gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)