### PR TITLE
feat(plugins): autoload project-local rules from .vguard/rules/custom/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Project-local rule autoloader for `.vguard/rules/custom/`.** Rule
+  files placed under `<projectRoot>/.vguard/rules/custom/**/*.{ts,js,mjs}`
+  are now picked up at config resolution time and registered alongside
+  built-in and plugin rules. Previously these files were orphans — the
+  `auto-configure` skill wrote them and they looked valid, but nothing
+  scanned the directory, so `vguard doctor` reported green while the
+  rules were inert. Local rules are discovered by `lint`, `generate`,
+  `rules list`, `doctor`, and by the runtime hook entry. Their
+  effective severity is capped at `warn` (block-severity enforcement
+  still requires a published plugin via `config.plugins`) to keep the
+  supply-chain trust model explicit: anything that can stop a
+  developer mid-edit has been through an npm publish. `doctor` now
+  surfaces load errors, severity downgrades, and the registered-rule
+  count under a `Local rules` check. Fixes #44.
 - **`sweep-gitignore` skill** under `ai-for-vibe-guard/skills/`.
   Dispatches parallel category sub-agents (build artefacts, deps,
   IDE/OS cruft, secrets/env, logs/caches) to audit a repo for files

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -8,6 +8,7 @@ import { discoverConfigFile, readRawConfig } from '../../config/discovery.js';
 import { resolveConfig } from '../../config/loader.js';
 import { getAllPresets } from '../../config/presets.js';
 import { getAllRules } from '../../engine/registry.js';
+import { loadLocalRules } from '../../plugins/local-rule-loader.js';
 import { readPerfEntries, calculatePerfStats, PERF_BUDGET_MS } from '../../engine/perf.js';
 import { createIgnoreMatcher, HARDCODED_DEFAULTS } from '../../utils/ignore.js';
 import type { VGuardConfig } from '../../types.js';
@@ -52,6 +53,35 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<void> 
     status: 'pass',
     message: `Found ${discovered.path}`,
   });
+
+  // Load project-local rules from .vguard/rules/custom/ before resolving
+  // the config so any rule IDs referenced there are in the registry.
+  const localRuleResult = await loadLocalRules(projectRoot);
+  if (localRuleResult.directoryExists) {
+    if (localRuleResult.errors.length > 0) {
+      for (const err of localRuleResult.errors) {
+        results.push({
+          name: `Local rule: ${err.file}`,
+          status: 'warn',
+          message: err.error,
+        });
+      }
+    }
+    if (localRuleResult.downgraded.length > 0) {
+      results.push({
+        name: 'Local rule severity',
+        status: 'warn',
+        message:
+          `${localRuleResult.downgraded.length} local rule(s) downgraded to "warn". ` +
+          'Block-severity enforcement requires a published plugin via `config.plugins`.',
+      });
+    }
+    results.push({
+      name: 'Local rules',
+      status: 'pass',
+      message: `${localRuleResult.rulesAdded} rule(s) loaded from .vguard/rules/custom/`,
+    });
+  }
 
   let resolvedConfig;
   let rawConfig: VGuardConfig;

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -9,6 +9,7 @@ import { compileConfig } from '../../config/compile.js';
 import { getAllPresets } from '../../config/presets.js';
 import { resolveConfig } from '../../config/loader.js';
 import { discoverConfigFile, readRawConfig } from '../../config/discovery.js';
+import { loadLocalRules } from '../../plugins/local-rule-loader.js';
 import { claudeCodeAdapter } from '../../adapters/claude-code/adapter.js';
 import { cursorAdapter } from '../../adapters/cursor/adapter.js';
 import { codexAdapter } from '../../adapters/codex/adapter.js';
@@ -40,6 +41,7 @@ export async function generateCommand(): Promise<void> {
   }
 
   const spinner = startSpinner('Resolving config');
+  await loadLocalRules(projectRoot);
   const rawConfig = await readRawConfig(discovered);
   const presetMap = getAllPresets();
   const resolvedConfig = resolveConfig(rawConfig as VGuardConfig, presetMap);

--- a/src/cli/commands/lint.ts
+++ b/src/cli/commands/lint.ts
@@ -4,6 +4,7 @@ import '../../rules/index.js';
 import { discoverConfigFile, readRawConfig } from '../../config/discovery.js';
 import { resolveConfig } from '../../config/loader.js';
 import { getAllPresets } from '../../config/presets.js';
+import { loadLocalRules } from '../../plugins/local-rule-loader.js';
 import { scanProject } from '../../engine/scanner.js';
 import { formatText } from '../formatters/text.js';
 import { formatGitHubActions } from '../formatters/github-actions.js';
@@ -26,6 +27,7 @@ export async function lintCommand(options: { format?: string }): Promise<void> {
   const format = options.format ?? 'text';
   const machineOutput = format === 'json' || format === 'github-actions' || format === 'ndjson';
 
+  await loadLocalRules(projectRoot);
   const rawConfig = await readRawConfig(discovered);
   const presetMap = getAllPresets();
   const resolvedConfig = resolveConfig(rawConfig as VGuardConfig, presetMap);

--- a/src/cli/commands/rules.ts
+++ b/src/cli/commands/rules.ts
@@ -9,6 +9,7 @@ import { getAllRules } from '../../engine/registry.js';
 import { discoverConfigFile, readRawConfig } from '../../config/discovery.js';
 import { resolveConfig } from '../../config/loader.js';
 import { getAllPresets } from '../../config/presets.js';
+import { loadLocalRules } from '../../plugins/local-rule-loader.js';
 import type { VGuardConfig } from '../../types.js';
 import { printBanner } from '../ui/banner.js';
 import { color } from '../ui/colors.js';
@@ -18,6 +19,7 @@ import { EXIT } from '../exit-codes.js';
 
 export async function rulesListCommand(options: { all?: boolean; json?: boolean }): Promise<void> {
   const projectRoot = process.cwd();
+  await loadLocalRules(projectRoot);
   const allRules = getAllRules();
 
   const discovered = discoverConfigFile(projectRoot);

--- a/src/engine/hook-entry.ts
+++ b/src/engine/hook-entry.ts
@@ -24,6 +24,7 @@ import { createIgnoreMatcher } from '../utils/ignore.js';
 
 // Import and register all built-in rules
 import '../rules/index.js';
+import { loadLocalRules } from '../plugins/local-rule-loader.js';
 
 /**
  * Main hook execution function.
@@ -47,6 +48,11 @@ export async function executeHook(event: HookEvent): Promise<void> {
     if (!config) {
       process.exit(0); // No config = no enforcement
     }
+
+    // 2b. Register project-local rules from .vguard/rules/custom/ so any
+    // rule IDs the resolved config references are actually in the registry.
+    // Fail-open: loader records errors internally but never throws.
+    await loadLocalRules(process.cwd());
 
     // 3. Extract tool info + session identifier
     const { toolName } = extractToolInput(rawInput);

--- a/src/plugins/local-rule-loader.ts
+++ b/src/plugins/local-rule-loader.ts
@@ -1,0 +1,184 @@
+import { readdirSync, statSync, existsSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import type { Rule } from '../types.js';
+import { registerRule, hasRule } from '../engine/registry.js';
+
+const LOCAL_RULES_DIR = '.vguard/rules/custom';
+const SUPPORTED_EXTENSIONS = new Set(['.ts', '.js', '.mjs']);
+const MAX_LOCAL_SEVERITY: 'block' | 'warn' | 'info' = 'warn';
+
+export interface LocalRuleLoadResult {
+  /** Files that were successfully loaded and registered. */
+  loaded: string[];
+  /** Files that could not be loaded, with the reason why. */
+  errors: Array<{ file: string; error: string }>;
+  /** Number of rules registered. */
+  rulesAdded: number;
+  /** Whether the `.vguard/rules/custom/` directory existed at all. */
+  directoryExists: boolean;
+  /** Files that were downgraded from `block` to `warn`. */
+  downgraded: string[];
+}
+
+interface LoadOptions {
+  /** Skip the on-disk scan entirely (used when config.localRules === false). */
+  disabled?: boolean;
+}
+
+/**
+ * Discover, validate, and register project-local rule files under
+ * `<projectRoot>/.vguard/rules/custom/`.
+ *
+ * Trust model: local rules are authored by the same people who author the
+ * repo's source code, so we trust them to run — but they have not been
+ * through the npm publish process, so we cap their effective severity at
+ * `warn`. Blocking severity continues to require a published plugin via
+ * `config.plugins`. Block-severity local rules are downgraded, not
+ * refused, so a user who moved a rule into `.vguard/rules/custom/` to
+ * iterate on it gets feedback instead of silence.
+ *
+ * Fail-open: import failures, shape-validation errors, and registry
+ * conflicts are recorded in the returned `errors` array but never throw.
+ * The caller (e.g. `vguard doctor`) decides whether to surface them.
+ */
+export async function loadLocalRules(
+  projectRoot: string,
+  options: LoadOptions = {},
+): Promise<LocalRuleLoadResult> {
+  const result: LocalRuleLoadResult = {
+    loaded: [],
+    errors: [],
+    rulesAdded: 0,
+    directoryExists: false,
+    downgraded: [],
+  };
+
+  const dir = join(projectRoot, LOCAL_RULES_DIR);
+  if (!existsSync(dir)) return result;
+  result.directoryExists = true;
+
+  if (options.disabled) return result;
+
+  const files = collectRuleFiles(dir);
+  if (files.length === 0) return result;
+
+  const { createJiti } = await import('jiti');
+  const jiti = createJiti(join(projectRoot, 'package.json'), {
+    interopDefault: true,
+  });
+
+  for (const file of files) {
+    const relPath = relative(projectRoot, file);
+    try {
+      const mod = (await jiti.import(file)) as Record<string, unknown>;
+      const exported =
+        mod && typeof mod === 'object' && 'default' in mod
+          ? (mod as { default: unknown }).default
+          : mod;
+
+      const validation = validateLocalRule(exported, relPath);
+      if (!validation.valid || !validation.rule) {
+        result.errors.push({ file: relPath, error: validation.errors.join('; ') });
+        continue;
+      }
+
+      let rule = validation.rule;
+      if (rule.severity === 'block') {
+        rule = { ...rule, severity: MAX_LOCAL_SEVERITY };
+        result.downgraded.push(relPath);
+      }
+
+      if (hasRule(rule.id)) {
+        result.errors.push({
+          file: relPath,
+          error: `rule id "${rule.id}" conflicts with an existing rule (built-in or plugin)`,
+        });
+        continue;
+      }
+
+      registerRule(rule);
+      result.loaded.push(relPath);
+      result.rulesAdded += 1;
+    } catch (err) {
+      result.errors.push({
+        file: relPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return result;
+}
+
+function collectRuleFiles(dir: string): string[] {
+  const out: string[] = [];
+  try {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      const stat = statSync(full);
+      if (stat.isDirectory()) {
+        out.push(...collectRuleFiles(full));
+        continue;
+      }
+      if (!stat.isFile()) continue;
+      const lower = entry.toLowerCase();
+      if (lower.endsWith('.d.ts')) continue;
+      const dot = lower.lastIndexOf('.');
+      if (dot < 0) continue;
+      const ext = lower.slice(dot);
+      if (SUPPORTED_EXTENSIONS.has(ext)) out.push(full);
+    }
+  } catch {
+    // Unreadable subdirectories are skipped quietly.
+  }
+  return out;
+}
+
+interface LocalRuleValidation {
+  valid: boolean;
+  errors: string[];
+  rule?: Rule;
+}
+
+/**
+ * Shape-check an imported module's default export against the `Rule`
+ * contract. Reused checks mirror `validatePlugin` so local-rule authors
+ * see the same error surface as plugin authors.
+ */
+export function validateLocalRule(candidate: unknown, label: string): LocalRuleValidation {
+  const errors: string[] = [];
+
+  if (!candidate || typeof candidate !== 'object') {
+    return { valid: false, errors: [`${label}: default export is not an object`] };
+  }
+
+  const rule = candidate as Partial<Rule>;
+
+  if (!rule.id || typeof rule.id !== 'string') {
+    errors.push(`${label}: rule is missing "id" string field`);
+  } else if (!rule.id.includes('/')) {
+    errors.push(`${label}: rule id "${rule.id}" must follow category/name format`);
+  }
+
+  if (!rule.name || typeof rule.name !== 'string') {
+    errors.push(`${label}: rule "${rule.id ?? '?'}" is missing "name" field`);
+  }
+
+  if (!rule.check || typeof rule.check !== 'function') {
+    errors.push(`${label}: rule "${rule.id ?? '?'}" is missing "check" function`);
+  }
+
+  if (!Array.isArray(rule.events) || rule.events.length === 0) {
+    errors.push(`${label}: rule "${rule.id ?? '?'}" must specify at least one event`);
+  }
+
+  if (!rule.severity || !['block', 'warn', 'info'].includes(rule.severity)) {
+    errors.push(`${label}: rule "${rule.id ?? '?'}" has invalid or missing severity`);
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, errors: [], rule: rule as Rule };
+}

--- a/tests/plugins/local-rule-loader.test.ts
+++ b/tests/plugins/local-rule-loader.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { loadLocalRules, validateLocalRule } from '../../src/plugins/local-rule-loader.js';
+import { clearRegistry, getRule } from '../../src/engine/registry.js';
+
+describe('validateLocalRule', () => {
+  it('rejects null / non-object default exports', () => {
+    expect(validateLocalRule(null, 'x.ts').valid).toBe(false);
+    expect(validateLocalRule(42, 'x.ts').valid).toBe(false);
+    expect(validateLocalRule('nope', 'x.ts').valid).toBe(false);
+  });
+
+  it('requires category/name id format', () => {
+    const res = validateLocalRule(
+      {
+        id: 'no-slash',
+        name: 'x',
+        severity: 'warn',
+        events: ['PreToolUse'],
+        check: () => ({ status: 'pass', ruleId: 'no-slash' }),
+      },
+      'x.ts',
+    );
+    expect(res.valid).toBe(false);
+    expect(res.errors.join(' ')).toMatch(/category\/name format/);
+  });
+
+  it('requires a check function and at least one event', () => {
+    const res = validateLocalRule(
+      {
+        id: 'custom/foo',
+        name: 'Foo',
+        severity: 'warn',
+        events: [],
+      },
+      'foo.ts',
+    );
+    expect(res.valid).toBe(false);
+    expect(res.errors.some((e) => /check/.test(e))).toBe(true);
+    expect(res.errors.some((e) => /event/.test(e))).toBe(true);
+  });
+
+  it('accepts a well-shaped rule', () => {
+    const res = validateLocalRule(
+      {
+        id: 'custom/foo',
+        name: 'Foo',
+        severity: 'warn',
+        events: ['PreToolUse'],
+        check: () => ({ status: 'pass', ruleId: 'custom/foo' }),
+      },
+      'foo.ts',
+    );
+    expect(res.valid).toBe(true);
+    expect(res.rule?.id).toBe('custom/foo');
+  });
+});
+
+describe('loadLocalRules', () => {
+  let projectRoot: string;
+
+  beforeEach(() => {
+    clearRegistry();
+    projectRoot = mkdtempSync(join(tmpdir(), 'vguard-local-rule-'));
+  });
+
+  afterEach(() => {
+    if (existsSync(projectRoot)) {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('returns directoryExists=false when .vguard/rules/custom is absent', async () => {
+    const result = await loadLocalRules(projectRoot);
+    expect(result.directoryExists).toBe(false);
+    expect(result.rulesAdded).toBe(0);
+  });
+
+  it('loads a well-formed .js rule and registers it', async () => {
+    const dir = join(projectRoot, '.vguard', 'rules', 'custom');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'foo.mjs'),
+      `export default {
+        id: 'custom/foo',
+        name: 'Foo',
+        description: 'd',
+        severity: 'warn',
+        events: ['PreToolUse'],
+        match: {},
+        check: () => ({ status: 'pass', ruleId: 'custom/foo' }),
+      };`,
+    );
+
+    const result = await loadLocalRules(projectRoot);
+    expect(result.directoryExists).toBe(true);
+    expect(result.rulesAdded).toBe(1);
+    expect(result.loaded).toHaveLength(1);
+    expect(result.errors).toHaveLength(0);
+    expect(getRule('custom/foo')).toBeDefined();
+  });
+
+  it('downgrades block-severity local rules to warn', async () => {
+    const dir = join(projectRoot, '.vguard', 'rules', 'custom');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'strict.mjs'),
+      `export default {
+        id: 'custom/strict',
+        name: 'Strict',
+        description: 'd',
+        severity: 'block',
+        events: ['PreToolUse'],
+        match: {},
+        check: () => ({ status: 'pass', ruleId: 'custom/strict' }),
+      };`,
+    );
+
+    const result = await loadLocalRules(projectRoot);
+    expect(result.rulesAdded).toBe(1);
+    expect(result.downgraded).toHaveLength(1);
+    expect(getRule('custom/strict')?.severity).toBe('warn');
+  });
+
+  it('records malformed modules in errors without throwing', async () => {
+    const dir = join(projectRoot, '.vguard', 'rules', 'custom');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'broken.mjs'), 'export default { id: "no-slash" };');
+
+    const result = await loadLocalRules(projectRoot);
+    expect(result.rulesAdded).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].file).toMatch(/broken/);
+  });
+
+  it('skips the scan when disabled=true', async () => {
+    const dir = join(projectRoot, '.vguard', 'rules', 'custom');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'foo.mjs'),
+      `export default {
+        id: 'custom/foo',
+        name: 'Foo',
+        description: 'd',
+        severity: 'warn',
+        events: ['PreToolUse'],
+        match: {},
+        check: () => ({ status: 'pass', ruleId: 'custom/foo' }),
+      };`,
+    );
+
+    const result = await loadLocalRules(projectRoot, { disabled: true });
+    expect(result.directoryExists).toBe(true);
+    expect(result.rulesAdded).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #44.

Rule files placed under `<projectRoot>/.vguard/rules/custom/**/*.{ts,js,mjs}` were documented by the `auto-configure` skill as the drop point for repo-specific heuristic rules, but nothing actually scanned the directory. `doctor` reported green, `rules list` omitted them, and `lint` / `generate` / the hook runtime never evaluated them. Users took the skill's output at face value and ended up with inert files.

## What changed

- **New loader**: `src/plugins/local-rule-loader.ts#loadLocalRules(root)`. Scans `.vguard/rules/custom/`, imports each `.ts|.js|.mjs` via jiti, pulls `default` export, validates shape, rejects registry conflicts, registers the rule. Per-file failures are accumulated; directory absence is a no-op.
- **Wired into**: `lint`, `generate`, `rules list`, `doctor` (all CLI surfaces that read the rule registry), plus `src/engine/hook-entry.ts` so runtime enforcement actually executes locally-registered rule IDs.
- **Trust model**: local rules share the repo's own trust boundary, so they run — but they have not been through an npm publish, so their effective severity is capped at `warn`. `block`-severity local rules are downgraded and the downgrade is surfaced by `doctor`. Block enforcement still requires a published plugin via `config.plugins`.
- **Doctor surface**: new `Local rules` check (rule count), `Local rule: <file>` warnings for load errors, `Local rule severity` warning when rules are downgraded.

## Test plan

- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm test` — 1430 tests pass (+9 new in `tests/plugins/local-rule-loader.test.ts`)
- [x] Shape validation cases (null / missing id format / missing check / missing events / well-formed)
- [x] Directory absence returns `directoryExists: false`
- [x] `.mjs` rule loads and registers
- [x] `block` severity downgrades to `warn`
- [x] Malformed module logged as error, loader doesn't throw
- [x] `disabled: true` short-circuits the scan
- [ ] Manual: re-run the issue-#44 repro — drop a rule into `.vguard/rules/custom/`, run `vguard doctor` + `vguard rules list` — rule should be counted

🤖 Generated with [Claude Code](https://claude.com/claude-code)