### PR TITLE
feat(config): implement monorepo.overrides for per-workspace rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`monorepo.overrides` is now applied.** The field has been declared
+  and schema-validated since v3.0 but was never consumed — a user
+  could write `monorepo.overrides['apps/mobile'] = { presets: ['react-native'] }`
+  and the preset would be silently ignored. New
+  `src/config/workspace-overrides.ts` resolves the most-specific
+  matching override key (fewest wildcards, longest literal prefix,
+  declaration order) and `resolveConfigForFile(userConfig, filePath, presetMap)`
+  layers the override's `presets` / `rules` over the root config
+  before returning a `ResolvedConfig`. `vguard lint` now threads the
+  raw config + presetMap into the scanner, which caches per-workspace
+  resolutions so files in the same workspace share a rule set. Works
+  with single-star (`apps/*`), double-star (`apps/**`), and literal
+  (`apps/mobile`) keys. Runtime hooks still use the flat compiled
+  config; extending `.vguard/cache/resolved-config.json` to persist
+  the override table will land in a follow-up. Fixes #56.
 - **Local-rule path list persisted into the pre-compiled config cache.**
   `vguard generate` now records the `.loaded` file list from
   `loadLocalRules()` into the new `localRulePaths` field of

--- a/src/cli/commands/lint.ts
+++ b/src/cli/commands/lint.ts
@@ -30,12 +30,15 @@ export async function lintCommand(options: { format?: string }): Promise<void> {
   await loadLocalRules(projectRoot);
   const rawConfig = await readRawConfig(discovered);
   const presetMap = getAllPresets();
-  const resolvedConfig = resolveConfig(rawConfig as VGuardConfig, presetMap);
+  const typedConfig = rawConfig as VGuardConfig;
+  const resolvedConfig = resolveConfig(typedConfig, presetMap);
 
   const spinner = machineOutput ? null : startSpinner('Scanning project');
   const result = await scanProject({
     rootDir: projectRoot,
     config: resolvedConfig,
+    userConfig: typedConfig,
+    presetMap,
   });
   spinner?.succeed(`Scanned ${result.filesScanned} files`);
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -9,6 +9,7 @@ import { vguardConfigSchema } from './schema.js';
 import { DEFAULT_CONFIG } from './defaults.js';
 import { discoverConfigFile, readRawConfig } from './discovery.js';
 import { getProfileSeverity, type ProfileName } from './profiles.js';
+import { applyWorkspaceOverride } from './workspace-overrides.js';
 
 /**
  * Load and resolve the VGuard config from a project root.
@@ -156,6 +157,23 @@ export function resolveConfig(
     cloud: config.cloud,
     enforcement: config.enforcement ?? 'hybrid',
   };
+}
+
+/**
+ * Resolve a user config for a specific touched file, applying any matching
+ * `monorepo.overrides[<glob>]` entry before delegating to `resolveConfig`.
+ *
+ * Used by `lint` (per-file scan) and by any caller that knows which file
+ * triggered enforcement. When `filePath` is undefined or no override
+ * matches, behaves identically to `resolveConfig`.
+ */
+export function resolveConfigForFile(
+  userConfig: VGuardConfig,
+  filePath: string | undefined,
+  presetMap?: Map<string, Preset>,
+): ResolvedConfig {
+  const effective = applyWorkspaceOverride(userConfig, filePath);
+  return resolveConfig(effective, presetMap);
 }
 
 /**

--- a/src/config/workspace-overrides.ts
+++ b/src/config/workspace-overrides.ts
@@ -1,0 +1,111 @@
+import type { MonorepoConfig, RuleConfig, VGuardConfig } from '../types.js';
+
+/**
+ * Resolve which monorepo override entry (if any) applies to a file path.
+ *
+ * Given a `monorepo.overrides` map keyed by workspace glob (e.g.
+ * `apps/mobile`, `apps/*`, `packages/ui`), this returns the entry whose
+ * key matches the longest prefix of the project-relative `filePath`.
+ * "Most specific" is defined as the fewest wildcards; ties are broken
+ * by longest literal prefix, then by declaration order.
+ *
+ * Returns `null` when:
+ *   - `filePath` is absent,
+ *   - `monorepo.overrides` is empty,
+ *   - no key matches the file.
+ */
+export function findWorkspaceOverride(
+  monorepo: MonorepoConfig | undefined,
+  filePath: string | undefined,
+): { presets?: string[]; rules?: Record<string, RuleConfig | boolean> } | null {
+  if (!monorepo?.overrides || !filePath) return null;
+
+  const normalised = filePath.replace(/\\/g, '/').replace(/^\.\//, '');
+
+  type Candidate = {
+    key: string;
+    literalPrefixLen: number;
+    wildcardCount: number;
+    value: { presets?: string[]; rules?: Record<string, RuleConfig | boolean> };
+    index: number;
+  };
+
+  const candidates: Candidate[] = [];
+  let index = 0;
+  for (const [key, value] of Object.entries(monorepo.overrides)) {
+    const pattern = key.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/$/, '');
+    if (matchesWorkspaceGlob(pattern, normalised)) {
+      const wildcardCount = (pattern.match(/\*/g) ?? []).length;
+      const literalPrefixLen = literalPrefixLength(pattern);
+      candidates.push({
+        key,
+        literalPrefixLen,
+        wildcardCount,
+        value: value as Candidate['value'],
+        index,
+      });
+    }
+    index += 1;
+  }
+
+  if (candidates.length === 0) return null;
+
+  candidates.sort((a, b) => {
+    // Fewer wildcards = more specific.
+    if (a.wildcardCount !== b.wildcardCount) return a.wildcardCount - b.wildcardCount;
+    // Longer literal prefix = more specific.
+    if (a.literalPrefixLen !== b.literalPrefixLen) return b.literalPrefixLen - a.literalPrefixLen;
+    // Tie-break by declaration order so the first-declared wins.
+    return a.index - b.index;
+  });
+
+  return candidates[0].value;
+}
+
+/**
+ * Produce a VGuardConfig with the matching workspace override layered
+ * on top of the root config. Only `presets` and `rules` are carried
+ * over from the override; other fields (agents, cloud, etc.) remain
+ * from the root.
+ */
+export function applyWorkspaceOverride(
+  base: VGuardConfig,
+  filePath: string | undefined,
+): VGuardConfig {
+  const override = findWorkspaceOverride(base.monorepo, filePath);
+  if (!override) return base;
+
+  return {
+    ...base,
+    presets: override.presets ?? base.presets,
+    rules: {
+      ...(base.rules ?? {}),
+      ...(override.rules ?? {}),
+    },
+  };
+}
+
+/** Match a single workspace-style glob against a POSIX-normalised path.
+ *  Supports `*` (single path segment), `**` (any subtree), and literal
+ *  directory prefixes. `apps/mobile` matches `apps/mobile`,
+ *  `apps/mobile/foo.ts`, and `apps/mobile/nested/bar.ts` — anything
+ *  rooted under that prefix.
+ */
+function matchesWorkspaceGlob(pattern: string, path: string): boolean {
+  const escaped = pattern
+    .split('/')
+    .map((segment) =>
+      segment === '**'
+        ? '(?:.*)'
+        : segment.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '[^/]*'),
+    )
+    .join('/');
+  const re = new RegExp(`^${escaped}(/.*)?$`);
+  return re.test(path);
+}
+
+/** Count the literal characters leading up to the first `*` in a glob. */
+function literalPrefixLength(pattern: string): number {
+  const star = pattern.indexOf('*');
+  return star < 0 ? pattern.length : star;
+}

--- a/src/engine/scanner.ts
+++ b/src/engine/scanner.ts
@@ -1,10 +1,12 @@
 import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { join } from 'node:path';
-import type { Rule, HookContext, ResolvedConfig } from '../types.js';
+import { join, relative } from 'node:path';
+import type { Rule, HookContext, ResolvedConfig, VGuardConfig, Preset } from '../types.js';
 import { getAllRules } from './registry.js';
 import { normalizePath, getExtension, matchesPattern } from '../utils/path.js';
 import { buildGitContext } from '../utils/git.js';
 import { createIgnoreMatcher, type IgnoreMatcher } from '../utils/ignore.js';
+import { resolveConfigForFile } from '../config/loader.js';
+import { findWorkspaceOverride } from '../config/workspace-overrides.js';
 
 /** A single issue found during scanning */
 export interface ScanIssue {
@@ -32,6 +34,13 @@ export interface ScanOptions {
    * matcher is created from `.vguardignore` + built-in defaults at `rootDir`.
    */
   ignoreMatcher?: IgnoreMatcher;
+  /**
+   * When provided alongside `presetMap`, the scanner re-resolves the
+   * config per file using `config.monorepo.overrides`. Omit both to
+   * keep the default single-config behaviour.
+   */
+  userConfig?: VGuardConfig;
+  presetMap?: Map<string, Preset>;
 }
 
 const SCANNABLE_EXTENSIONS = new Set([
@@ -59,23 +68,50 @@ export async function scanProject(options: ScanOptions): Promise<ScanResult> {
   const allRules = getAllRules();
   const gitContext = buildGitContext(rootDir);
 
-  // Collect applicable rules (only Write-matching rules work in scan mode)
-  const scanRules: Array<{
+  type ScanRuleSet = Array<{
     rule: Rule;
-    config: typeof config.rules extends Map<string, infer V> ? V : never;
-  }> = [];
+    config: ResolvedConfig['rules'] extends Map<string, infer V> ? V : never;
+  }>;
 
-  for (const [ruleId, ruleConfig] of config.rules) {
-    if (!ruleConfig.enabled) continue;
-    const rule = allRules.get(ruleId);
-    if (!rule) continue;
+  function buildScanRules(rc: ResolvedConfig): ScanRuleSet {
+    const out: ScanRuleSet = [];
+    for (const [ruleId, ruleConfig] of rc.rules) {
+      if (!ruleConfig.enabled) continue;
+      const rule = allRules.get(ruleId);
+      if (!rule) continue;
+      if (rule.match?.tools && !rule.match.tools.includes('Write')) continue;
+      if (rule.events.length === 1 && rule.events[0] === 'Stop') continue;
+      out.push({ rule, config: ruleConfig });
+    }
+    return out;
+  }
 
-    // Only include rules that match Write tool (scan simulates Write)
-    if (rule.match?.tools && !rule.match.tools.includes('Write')) continue;
-    // Skip Stop-only rules
-    if (rule.events.length === 1 && rule.events[0] === 'Stop') continue;
+  const defaultScanRules = buildScanRules(config);
 
-    scanRules.push({ rule, config: ruleConfig });
+  // Per-workspace cache so files that match the same override share a
+  // resolved config and scan-rule set.
+  const workspaceCache = new Map<string, { cfg: ResolvedConfig; scanRules: ScanRuleSet }>();
+  const hasOverrides =
+    options.userConfig?.monorepo?.overrides &&
+    Object.keys(options.userConfig.monorepo.overrides).length > 0 &&
+    options.presetMap;
+
+  function resolveForFile(filePath: string): { cfg: ResolvedConfig; scanRules: ScanRuleSet } {
+    if (!hasOverrides) return { cfg: config, scanRules: defaultScanRules };
+    const relPath = relative(rootDir, filePath).replace(/\\/g, '/');
+    const match = findWorkspaceOverride(options.userConfig!.monorepo, relPath);
+    if (!match) return { cfg: config, scanRules: defaultScanRules };
+
+    // Cache key: the stringified override keys that matched. Use the
+    // override reference identity via JSON of keys it touches.
+    const cacheKey = JSON.stringify({ p: match.presets ?? null, r: match.rules ?? null });
+    let cached = workspaceCache.get(cacheKey);
+    if (!cached) {
+      const cfg = resolveConfigForFile(options.userConfig!, relPath, options.presetMap);
+      cached = { cfg, scanRules: buildScanRules(cfg) };
+      workspaceCache.set(cacheKey, cached);
+    }
+    return cached;
   }
 
   // Walk the directory
@@ -93,6 +129,8 @@ export async function scanProject(options: ScanOptions): Promise<ScanResult> {
       continue;
     }
 
+    const { cfg: fileConfig, scanRules: fileScanRules } = resolveForFile(filePath);
+
     // Build a synthetic HookContext for this file
     const context: HookContext = {
       event: 'PreToolUse',
@@ -101,12 +139,12 @@ export async function scanProject(options: ScanOptions): Promise<ScanResult> {
         file_path: filePath,
         content,
       },
-      projectConfig: config,
+      projectConfig: fileConfig,
       gitContext,
     };
 
     // Run applicable rules
-    for (const { rule, config: ruleConfig } of scanRules) {
+    for (const { rule, config: ruleConfig } of fileScanRules) {
       // Check file match patterns
       if (rule.match?.include && !matchesPattern(filePath, rule.match.include)) continue;
       if (rule.match?.exclude && matchesPattern(filePath, rule.match.exclude)) continue;

--- a/tests/config/workspace-overrides.test.ts
+++ b/tests/config/workspace-overrides.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findWorkspaceOverride,
+  applyWorkspaceOverride,
+} from '../../src/config/workspace-overrides.js';
+import type { VGuardConfig } from '../../src/types.js';
+
+describe('findWorkspaceOverride', () => {
+  it('returns null when monorepo is undefined', () => {
+    expect(findWorkspaceOverride(undefined, 'apps/mobile/foo.ts')).toBeNull();
+  });
+
+  it('returns null when overrides is empty', () => {
+    expect(findWorkspaceOverride({ packages: ['apps/*'] }, 'apps/mobile/foo.ts')).toBeNull();
+  });
+
+  it('returns null when filePath is undefined', () => {
+    expect(
+      findWorkspaceOverride(
+        {
+          packages: ['apps/*'],
+          overrides: { 'apps/mobile': { presets: ['react-native'] } },
+        },
+        undefined,
+      ),
+    ).toBeNull();
+  });
+
+  it('matches a literal directory prefix', () => {
+    const result = findWorkspaceOverride(
+      {
+        packages: ['apps/*'],
+        overrides: { 'apps/mobile': { presets: ['react-native'] } },
+      },
+      'apps/mobile/src/foo.ts',
+    );
+    expect(result?.presets).toEqual(['react-native']);
+  });
+
+  it('matches a single-star glob', () => {
+    const result = findWorkspaceOverride(
+      {
+        packages: ['apps/*'],
+        overrides: { 'apps/*': { presets: ['web'] } },
+      },
+      'apps/web/foo.ts',
+    );
+    expect(result?.presets).toEqual(['web']);
+  });
+
+  it('prefers the most specific match (fewer wildcards)', () => {
+    const result = findWorkspaceOverride(
+      {
+        packages: ['apps/*'],
+        overrides: {
+          'apps/*': { presets: ['web'] },
+          'apps/mobile': { presets: ['react-native'] },
+        },
+      },
+      'apps/mobile/foo.ts',
+    );
+    expect(result?.presets).toEqual(['react-native']);
+  });
+
+  it('falls back to wildcard when no literal matches', () => {
+    const result = findWorkspaceOverride(
+      {
+        packages: ['apps/*'],
+        overrides: {
+          'apps/*': { presets: ['web'] },
+          'apps/mobile': { presets: ['react-native'] },
+        },
+      },
+      'apps/desktop/foo.ts',
+    );
+    expect(result?.presets).toEqual(['web']);
+  });
+
+  it('returns null for files outside any workspace', () => {
+    const result = findWorkspaceOverride(
+      {
+        packages: ['apps/*'],
+        overrides: { 'apps/*': { presets: ['web'] } },
+      },
+      'libs/shared/util.ts',
+    );
+    expect(result).toBeNull();
+  });
+
+  it('normalises backslash paths on Windows input', () => {
+    const result = findWorkspaceOverride(
+      {
+        packages: ['apps/*'],
+        overrides: { 'apps/mobile': { presets: ['react-native'] } },
+      },
+      'apps\\mobile\\foo.ts',
+    );
+    expect(result?.presets).toEqual(['react-native']);
+  });
+});
+
+describe('applyWorkspaceOverride', () => {
+  const baseConfig: VGuardConfig = {
+    presets: ['typescript-strict'],
+    agents: ['claude-code'],
+    rules: {
+      'security/branch-protection': { severity: 'block' },
+    },
+    monorepo: {
+      packages: ['apps/*', 'libs/*'],
+      overrides: {
+        'apps/mobile': {
+          presets: ['react-native'],
+          rules: { 'security/branch-protection': { severity: 'warn' } },
+        },
+      },
+    },
+  };
+
+  it('returns the base config when no match', () => {
+    const out = applyWorkspaceOverride(baseConfig, 'libs/shared/foo.ts');
+    expect(out.presets).toEqual(['typescript-strict']);
+    expect(out.rules?.['security/branch-protection']).toEqual({ severity: 'block' });
+  });
+
+  it('replaces presets with the override when a match is found', () => {
+    const out = applyWorkspaceOverride(baseConfig, 'apps/mobile/foo.ts');
+    expect(out.presets).toEqual(['react-native']);
+  });
+
+  it('merges override rules on top of base rules', () => {
+    const out = applyWorkspaceOverride(baseConfig, 'apps/mobile/foo.ts');
+    expect(out.rules?.['security/branch-protection']).toEqual({ severity: 'warn' });
+  });
+
+  it('preserves non-scoped fields (agents, cloud, etc.) from the base', () => {
+    const out = applyWorkspaceOverride(baseConfig, 'apps/mobile/foo.ts');
+    expect(out.agents).toEqual(['claude-code']);
+    expect(out.monorepo?.packages).toEqual(['apps/*', 'libs/*']);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #56.

\`monorepo.overrides\` has been declared in \`VGuardConfig\` and validated by the Zod schema since v3.0, but nothing consumed the field. A user could write per-workspace overrides and the engine would silently ignore them.

This PR implements the feature for the lint path.

## What changed

- **New \`src/config/workspace-overrides.ts\`** — \`findWorkspaceOverride(monorepo, filePath)\` picks the most-specific matching entry. Specificity = fewest wildcards → longest literal prefix → declaration order. Supports \`apps/*\`, \`apps/**\`, and literal (\`apps/mobile\`) keys; normalises Windows backslashes.
- **New \`resolveConfigForFile(userConfig, filePath, presetMap)\`** in \`src/config/loader.ts\` — layers matching override's \`presets\` + \`rules\` over the root config, then delegates to \`resolveConfig\`. Severity can still only be downgraded, matching existing preset semantics.
- **\`ScanOptions.userConfig\` / \`presetMap\`** — when present, the scanner re-resolves the config per file and caches by override identity so files in the same workspace share a rule set. Back-compat: omitting both preserves the original single-config behaviour.
- **\`vguard lint\`** threads raw config + presetMap through to the scanner.

## Scope / follow-up

Runtime hooks still consume the flat pre-compiled config at \`.vguard/cache/resolved-config.json\`. Extending that cache to persist the override table (so per-file runtime resolution matches lint) is the next step — tracked as a follow-up. This PR is the resolver primitives + lint wiring.

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run type-check\`
- [x] \`npm test\` — 1434 tests pass (+13 new in \`tests/config/workspace-overrides.test.ts\`)
- [x] Cases covered: null paths, empty overrides, literal-vs-wildcard specificity, files outside any workspace, Windows backslash input, \`findWorkspaceOverride\` + \`applyWorkspaceOverride\` round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)