### PR TITLE
docs(trust): document trust model + add VGUARD_NO_PLUGINS escape hatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`TRUST_MODEL.md`** at the repo root, linked from `README.md`.
+  Documents what running `vguard` against a repository actually executes
+  (`vguard.config.ts` = code; plugins = full-trust; local rules =
+  capped at warn), the cloud-sync redaction contract, and the
+  mitigations available for CI or untrusted-input flows. Addresses
+  #51.
+- **`VGUARD_NO_PLUGINS=1` escape hatch.** Setting the env var causes
+  `loadPlugins()` in `src/plugins/loader.ts` to short-circuit and
+  return an empty result without executing any plugin module code.
+  Built-in rules still run. Intended for CI runs against untrusted
+  repos where declared plugins should not auto-execute. Addresses
+  #51.
 - **`loadValidatedConfig()` helper** in `src/config/load-validated.ts`
   plus a `ConfigValidationError` class. Consolidates the
   discover → read → Zod-validate flow so hand-edited config typos fail

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ This project is maintained by [Anthril](https://github.com/anthril) and funded b
 - [Contributing](CONTRIBUTING.md)
 - [Code of Conduct](CODE_OF_CONDUCT.md)
 - [Security Policy](SECURITY.md)
+- [Trust Model](TRUST_MODEL.md) — what `vguard` commands actually execute, and how to lock it down in CI
 - [Changelog](CHANGELOG.md)
 
 ## License

--- a/TRUST_MODEL.md
+++ b/TRUST_MODEL.md
@@ -1,0 +1,134 @@
+# VGuard Trust Model
+
+This document describes what running VGuard against a repository actually
+executes, so you can make an informed call before pointing it at code
+you didn't author.
+
+Short version: **running any `vguard` command against a repository is a
+trust decision equivalent to `npm run <script>` on that repository.**
+Keep that sentence in mind and the rest of this document is detail.
+
+## What actually executes
+
+### 1. `vguard.config.ts` is code, not data
+
+VGuard's config is a TypeScript/JavaScript file loaded via
+[jiti](https://github.com/unjs/jiti) in `src/config/discovery.ts`.
+Anything at the top level of `vguard.config.ts` — `import`s, top-level
+`await`s, `console.log`s, network calls, file reads — runs on every
+`vguard` invocation, including `vguard doctor`, `vguard lint`, and every
+hook event.
+
+This is idiomatic for TS config (Next.js, Vite, Drizzle, ESLint flat
+config all work this way), but it is not hedged in the docs. Loading a
+`vguard.config.ts` from a hostile repository is equivalent to running
+`node ./vguard.config.ts` with your normal user permissions.
+
+### 2. Plugins are full-trust
+
+`config.plugins: ['@your-org/vguard-plugin-x']` is loaded by
+`src/plugins/loader.ts` via a dynamic `import()`. The plugin's module
+code runs at load time; the `Rule.check()` bodies it exports run inside
+every tool-call hook.
+
+`validatePlugin()` in `src/plugins/validator.ts` enforces the object
+_shape_ but does not sandbox behaviour. A plugin can:
+
+- read files on disk, including `.env`, `~/.ssh`, and other repo
+  contents;
+- call `fetch()` anywhere on the network;
+- spawn child processes;
+- mutate your environment.
+
+This is the same trust you extend to any npm package under
+`dependencies`. Be selective about who you install.
+
+### 3. Hooks generated under `.vguard/hooks/` are deterministic
+
+`vguard generate` compiles the current config into small Node scripts
+under `.vguard/hooks/`. Reviewing `vguard.config.ts` is equivalent to
+reviewing the hooks — rerunning `vguard generate` will reproduce them
+byte-for-byte.
+
+### 4. Project-local rules
+
+`.vguard/rules/custom/**/*.{ts,js,mjs}` are autoloaded at config
+resolution time. They run the same way plugins do, except their
+effective severity is capped at `warn` — block-severity enforcement
+still requires a published plugin via `config.plugins`. Local rules are
+authored by the same humans who author the repo, so we trust them to
+run; we don't trust them to block developers without going through an
+npm publish.
+
+### 5. Cloud sync
+
+When `cloud.enabled: true` is set, rule-hit payloads are streamed to
+`https://vguard.dev` (or whatever `VGUARD_CLOUD_URL` points at, subject
+to the allowlist in `src/cloud/url-guard.ts`). Payload contents are
+rule-hit records, which can include `filePath` and rule `message`
+fields. Before upload, VGuard:
+
+- scrubs paths matching `.vguardignore` / `cloud.excludePaths`;
+- redacts high-signal secret shapes (API keys, JWTs, PATs) in every
+  string field — see `src/cloud/sync.ts#scrubSecretsDeep`.
+
+Disable cloud sync and no network I/O happens for rule-hit data.
+
+## Recommended mitigations
+
+### For CI or any untrusted-input flow
+
+- **Disable plugins entirely.** Set `VGUARD_NO_PLUGINS=1` in the CI
+  environment. `src/plugins/loader.ts` short-circuits and no plugin
+  module code executes. The built-in rule set still runs.
+
+- **Prefer a JSON config** (`.vguardrc.json` or `package.json#vguard`)
+  over `vguard.config.ts` when you are running against repos you didn't
+  author. JSON is pure data; it cannot execute code the way a TS config
+  can.
+
+- **Pin and review plugin packages.** Plugins are published npm
+  packages — treat them exactly like any other runtime dependency.
+  Inspect before installing, pin versions, and audit updates.
+
+- **Pin the cloud endpoint.** Leave `VGUARD_CLOUD_URL` /
+  `VGUARD_FUNCTIONS_URL` unset unless you have a specific reason to
+  override them. The allowlist in `src/cloud/url-guard.ts` already
+  refuses arbitrary hosts, but not setting the variable at all removes
+  the dial altogether.
+
+### For local development
+
+- Read `vguard.config.ts` before running a VGuard command on an
+  unfamiliar repository, the same way you'd read `package.json#scripts`
+  before running `npm run dev`.
+- Prefer `vguard --help` for discovery; it does not load the config.
+- `vguard init` writes a minimal config you can inspect.
+
+## Environment variables that change behaviour
+
+| Variable               | Effect                                                                                           |
+| ---------------------- | ------------------------------------------------------------------------------------------------ |
+| `VGUARD_NO_PLUGINS=1`  | Skip loading any plugin module; built-in rules still run.                                        |
+| `VGUARD_DEV=1`         | Allow `http://` / private-IP cloud URLs (see `src/cloud/url-guard.ts`). Never set in production. |
+| `VGUARD_CLOUD_URL`     | Override the cloud API host. Must match the allowlist.                                           |
+| `VGUARD_FUNCTIONS_URL` | Override the Supabase functions host. Must end with `.supabase.co`.                              |
+| `VGUARD_API_KEY`       | Project API key for cloud sync (otherwise read from `~/.vguard/credentials.json`).               |
+
+## Long-term hardening (not yet shipped)
+
+The following are **not** currently implemented. They are named here so
+the trust model is honest about what is and isn't covered:
+
+- **Plugin sandboxing** via `node:vm` or a worker subprocess with
+  capability flags.
+- **Static analysis at plugin load time** that flags banned APIs
+  (`child_process`, `fs.readFile` outside the project, `fetch` to
+  non-vguard.dev hosts).
+- **Allow-listed plugin registry** with published hashes, so
+  `config.plugins` can reference a known-good set rather than arbitrary
+  packages.
+- **OS-keychain-backed credential storage** (today credentials live in
+  `~/.vguard/credentials.json` with `0o600` mode / Windows ACL).
+
+Track these via GitHub issues if you need them for a specific deploy.

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -26,6 +26,15 @@ export async function loadPlugins(pluginNames: string[]): Promise<PluginLoadResu
     presetsAdded: 0,
   };
 
+  // Trust-model escape hatch: CI or untrusted-input flows can set
+  // VGUARD_NO_PLUGINS=1 to skip loading any plugin. Plugin code runs
+  // with the full privileges of the vguard process, so this gate lets
+  // operators run linting in hostile repos without auto-executing
+  // whatever `plugins: [...]` happens to declare. See TRUST_MODEL.md.
+  if (process.env.VGUARD_NO_PLUGINS === '1') {
+    return result;
+  }
+
   for (const name of pluginNames) {
     if (!isValidNpmPackageName(name)) {
       result.errors.push({ plugin: name, error: `Invalid plugin name: "${name}"` });

--- a/tests/plugins/loader.test.ts
+++ b/tests/plugins/loader.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { loadPlugins } from '../../src/plugins/loader.js';
 
 // Register built-in rules
@@ -18,5 +18,29 @@ describe('loadPlugins', () => {
     expect(result.errors).toHaveLength(0);
     expect(result.rulesAdded).toBe(0);
     expect(result.presetsAdded).toBe(0);
+  });
+
+  describe('VGUARD_NO_PLUGINS trust-model escape hatch', () => {
+    const original = process.env.VGUARD_NO_PLUGINS;
+
+    afterEach(() => {
+      if (original === undefined) delete process.env.VGUARD_NO_PLUGINS;
+      else process.env.VGUARD_NO_PLUGINS = original;
+    });
+
+    it('skips plugin loading entirely when VGUARD_NO_PLUGINS=1', async () => {
+      process.env.VGUARD_NO_PLUGINS = '1';
+      const result = await loadPlugins(['vguard-plugin-nonexistent']);
+      expect(result.loaded).toHaveLength(0);
+      expect(result.errors).toHaveLength(0);
+      expect(result.rulesAdded).toBe(0);
+      expect(result.presetsAdded).toBe(0);
+    });
+
+    it('ignores values other than exactly "1"', async () => {
+      process.env.VGUARD_NO_PLUGINS = 'true';
+      const result = await loadPlugins(['vguard-plugin-nonexistent']);
+      expect(result.errors).toHaveLength(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Addresses #51.

VGuard's two executable paths — `vguard.config.ts` (jiti) and `config.plugins: [...]` (dynamic import) — have always run with the full privileges of the developer shell, but the trust implications have never been written down. Claude Code / Cursor users tend to trust VGuard precisely because it gates their edits; a compromised plugin or a malicious PR that tweaks `vguard.config.ts` is RCE they never opted into.

## What changed

- **`TRUST_MODEL.md`** at repo root, linked from `README.md`. Covers what each path actually executes, the cloud-sync redaction contract, and the mitigations available for CI or untrusted-input flows.
- **`VGUARD_NO_PLUGINS=1` escape hatch** wired into `src/plugins/loader.ts`. Short-circuits plugin loading with an empty result and no module imports. Built-in rules still run.

## Non-goals (explicit)

Documented in `TRUST_MODEL.md` so the scope is honest: plugin sandboxing via `node:vm`, static analysis of plugin code at load time, allow-listed plugin registry with published hashes, OS-keychain credential storage. These are tracked separately.

## Test plan

- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm test` — 1423 tests pass (+2 new in `tests/plugins/loader.test.ts`)
- [x] `VGUARD_NO_PLUGINS=1` skips plugin loading cleanly
- [x] `VGUARD_NO_PLUGINS=true` (or other non-"1") behaves normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)