### PR TITLE
chore(husky): enforce prettier + lockfile version in pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,12 @@
-npm run lint && npm run type-check
+npm run lint && npm run type-check && npm run format:check
+
+# ── Lockfile ↔ package.json version match ──
+# Catch the class of bug where package.json is bumped but the lockfile's
+# top-level `version` field is forgotten, so `npm ci` on a clean clone
+# reproduces the pre-bump tree. Surfaced from issue #52 on 2026-04-22.
+if [ -f package-lock.json ]; then
+  node -e 'const p=require("./package.json"); const l=require("./package-lock.json"); if (p.version !== l.version) { console.error("\n  ERROR: package-lock.json version ("+l.version+") does not match package.json ("+p.version+")."); console.error("  Fix: npm install --package-lock-only && git add package-lock.json\n"); process.exit(1); }' || exit 1
+fi
 
 # ── Skip CHANGELOG/version checks on merge commits ──
 # Merge commits consolidate existing history; they don't introduce new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Chore
 
+- **Pre-commit hook now runs `npm run format:check`** alongside the
+  existing lint + type-check. The previous hook shipped silent
+  Prettier drift to CI — caught during the plan-completion audit on
+  2026-04-22 when 9 of 12 in-flight PRs failed the `quality` job for
+  format-only reasons. Drift now fails at `git commit` time with a
+  clear Prettier message.
+- **Pre-commit hook now rejects `package-lock.json` version drift.**
+  The one-line Node guard runs after every commit attempt; on
+  mismatch it points at `npm install --package-lock-only`. Closes
+  the optional prevention half of #52 called out in PR #67.
 - **Regenerated `package-lock.json`** after the v2.0.1 → v3.0.0 bump
   so the lockfile's top-level `version` field matches `package.json`.
   `npm ci` now reproduces the intended dev tree instead of the v2.0.1


### PR DESCRIPTION
## Summary

Two tightenings of `.husky/pre-commit` surfaced by the plan-completion audit on 2026-04-22.

### `npm run format:check` added

The prior hook ran lint + type-check but not Prettier. 9 of 12 in-flight PRs shipped formatting drift and failed the CI `quality` job (which runs `npm run format:check`). Adding the check to the first line catches drift at `git commit` time with a clear Prettier message instead of after a push + CI run.

### `package-lock.json` ↔ `package.json` version match

Inline Node guard (no new deps) that compares the top-level `version` fields and refuses the commit with a pointer to `npm install --package-lock-only` on mismatch. This is the optional prevention half of #52 that PR #67 deferred.

## Base branch

This PR targets `chore/lockfile-and-extraneous-deps` (**PR #67**) instead of `dev`, because #67's lockfile-regen needs to land first or the new version-match guard would reject its own introduction commit. Please merge #67 first, then re-target this to `dev` if needed.

## Test plan

- [x] Commit that added the hook ran through the full new hook chain (lint + type-check + format:check + version-match), all passed
- [x] Verified the version-match guard on `dev` baseline reports the pre-fix drift correctly — `mismatch` output — confirming the detection works
- [ ] After #67 merges to `dev`, re-target this PR at `dev` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)