### PR TITLE
perf(config): cache workspace override matchers per config reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`monorepo.overrides` matcher compilation is now cached per
+  `MonorepoConfig` reference.** Previously every `findWorkspaceOverride`
+  call rebuilt a fresh `RegExp` per override key, so a lint run over
+  a 1000-file monorepo with 10 overrides paid 10,000 RegExp
+  constructions. Now a `WeakMap<MonorepoConfig, CompiledOverride[]>`
+  stores pre-built matchers + pre-computed specificity scores, so the
+  first lookup compiles once and every subsequent lookup against the
+  same config reference is a table walk. `buildWorkspaceGlobRegex` is
+  now a named export so the compile step is directly testable. Follow-up
+  to the perf note on PR #66.
 - **`vibeCheckConfigSchema` → `vguardConfigSchema`.** The Zod schema
   export was renamed to match the post-rebrand product name. The old
   identifier remains as a `@deprecated` re-export for one minor release

--- a/src/config/workspace-overrides.ts
+++ b/src/config/workspace-overrides.ts
@@ -1,5 +1,76 @@
 import type { MonorepoConfig, RuleConfig, VGuardConfig } from '../types.js';
 
+type OverrideValue = { presets?: string[]; rules?: Record<string, RuleConfig | boolean> };
+
+interface CompiledOverride {
+  /** Original override key (for debug output / error messages). */
+  key: string;
+  /** Pre-built matcher RegExp, anchored `^…$`. */
+  re: RegExp;
+  /** Number of `*` characters in the source pattern — fewer = more specific. */
+  wildcardCount: number;
+  /** Number of literal characters leading up to the first `*`. */
+  literalPrefixLen: number;
+  /** Declaration order in the original object — used as a tie-break. */
+  index: number;
+  /** Original override value (`presets` + `rules`). */
+  value: OverrideValue;
+}
+
+/**
+ * Per-MonorepoConfig cache of compiled matchers. Keyed on the object
+ * reference, so repeated `findWorkspaceOverride` calls against the same
+ * resolved config (typical of a `vguard lint` run) amortise the RegExp
+ * construction cost over every file touched — first call compiles, all
+ * subsequent calls reuse.
+ *
+ * `WeakMap` ensures we don't leak compiled matchers when the user
+ * reloads their config (the old `monorepo` reference becomes eligible
+ * for GC along with its cache entry).
+ */
+const compiledCache = new WeakMap<MonorepoConfig, CompiledOverride[]>();
+
+/**
+ * Test-only hook: total number of times `compileOverrides` has
+ * re-walked the override list since module load. Each increment
+ * corresponds to one `new RegExp` per override key — unchanged across
+ * repeated lookups against a cached `MonorepoConfig`, incremented
+ * once per fresh `MonorepoConfig` reference.
+ *
+ * Exported so the test suite can verify the cache without monkey-
+ * patching the global RegExp constructor (which vitest's `vi.spyOn`
+ * does poorly on `new`-invocations).
+ *
+ * Not part of the public contract; do not read outside tests.
+ */
+export const __testGetCompileCount = (): number => compileCount;
+let compileCount = 0;
+
+function compileOverrides(monorepo: MonorepoConfig): CompiledOverride[] {
+  const cached = compiledCache.get(monorepo);
+  if (cached) return cached;
+
+  compileCount += 1;
+  const overrides = monorepo.overrides ?? {};
+  const compiled: CompiledOverride[] = [];
+  let index = 0;
+  for (const [key, value] of Object.entries(overrides)) {
+    const pattern = key.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/$/, '');
+    compiled.push({
+      key,
+      re: buildWorkspaceGlobRegex(pattern),
+      wildcardCount: (pattern.match(/\*/g) ?? []).length,
+      literalPrefixLen: literalPrefixLength(pattern),
+      index,
+      value: value as OverrideValue,
+    });
+    index += 1;
+  }
+
+  compiledCache.set(monorepo, compiled);
+  return compiled;
+}
+
 /**
  * Resolve which monorepo override entry (if any) applies to a file path.
  *
@@ -9,6 +80,10 @@ import type { MonorepoConfig, RuleConfig, VGuardConfig } from '../types.js';
  * "Most specific" is defined as the fewest wildcards; ties are broken
  * by longest literal prefix, then by declaration order.
  *
+ * Matchers are compiled lazily and cached against the `monorepo`
+ * reference, so repeated calls in a single lint run don't pay the
+ * RegExp construction cost more than once per override key.
+ *
  * Returns `null` when:
  *   - `filePath` is absent,
  *   - `monorepo.overrides` is empty,
@@ -17,45 +92,26 @@ import type { MonorepoConfig, RuleConfig, VGuardConfig } from '../types.js';
 export function findWorkspaceOverride(
   monorepo: MonorepoConfig | undefined,
   filePath: string | undefined,
-): { presets?: string[]; rules?: Record<string, RuleConfig | boolean> } | null {
+): OverrideValue | null {
   if (!monorepo?.overrides || !filePath) return null;
+
+  const compiled = compileOverrides(monorepo);
+  if (compiled.length === 0) return null;
 
   const normalised = filePath.replace(/\\/g, '/').replace(/^\.\//, '');
 
-  type Candidate = {
-    key: string;
-    literalPrefixLen: number;
-    wildcardCount: number;
-    value: { presets?: string[]; rules?: Record<string, RuleConfig | boolean> };
-    index: number;
-  };
-
-  const candidates: Candidate[] = [];
-  let index = 0;
-  for (const [key, value] of Object.entries(monorepo.overrides)) {
-    const pattern = key.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/$/, '');
-    if (matchesWorkspaceGlob(pattern, normalised)) {
-      const wildcardCount = (pattern.match(/\*/g) ?? []).length;
-      const literalPrefixLen = literalPrefixLength(pattern);
-      candidates.push({
-        key,
-        literalPrefixLen,
-        wildcardCount,
-        value: value as Candidate['value'],
-        index,
-      });
+  const candidates: CompiledOverride[] = [];
+  for (const entry of compiled) {
+    if (entry.re.test(normalised)) {
+      candidates.push(entry);
     }
-    index += 1;
   }
 
   if (candidates.length === 0) return null;
 
   candidates.sort((a, b) => {
-    // Fewer wildcards = more specific.
     if (a.wildcardCount !== b.wildcardCount) return a.wildcardCount - b.wildcardCount;
-    // Longer literal prefix = more specific.
     if (a.literalPrefixLen !== b.literalPrefixLen) return b.literalPrefixLen - a.literalPrefixLen;
-    // Tie-break by declaration order so the first-declared wins.
     return a.index - b.index;
   });
 
@@ -85,13 +141,19 @@ export function applyWorkspaceOverride(
   };
 }
 
-/** Match a single workspace-style glob against a POSIX-normalised path.
- *  Supports `*` (single path segment), `**` (any subtree), and literal
- *  directory prefixes. `apps/mobile` matches `apps/mobile`,
- *  `apps/mobile/foo.ts`, and `apps/mobile/nested/bar.ts` — anything
- *  rooted under that prefix.
+/**
+ * Build the anchored RegExp for a single workspace glob.
+ *
+ * Supports `*` (single path segment) and `**` (any subtree). Literal
+ * directory prefixes match themselves and everything below them —
+ * `apps/mobile` matches `apps/mobile`, `apps/mobile/foo.ts`, and
+ * `apps/mobile/nested/bar.ts`. Regex metacharacters outside `*` are
+ * escaped.
+ *
+ * Exported for the test suite so the compile step can be exercised
+ * without going through the caching layer.
  */
-function matchesWorkspaceGlob(pattern: string, path: string): boolean {
+export function buildWorkspaceGlobRegex(pattern: string): RegExp {
   const escaped = pattern
     .split('/')
     .map((segment) =>
@@ -100,8 +162,7 @@ function matchesWorkspaceGlob(pattern: string, path: string): boolean {
         : segment.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '[^/]*'),
     )
     .join('/');
-  const re = new RegExp(`^${escaped}(/.*)?$`);
-  return re.test(path);
+  return new RegExp(`^${escaped}(/.*)?$`);
 }
 
 /** Count the literal characters leading up to the first `*` in a glob. */

--- a/tests/config/workspace-overrides.test.ts
+++ b/tests/config/workspace-overrides.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from 'vitest';
 import {
   findWorkspaceOverride,
   applyWorkspaceOverride,
+  buildWorkspaceGlobRegex,
+  __testGetCompileCount,
 } from '../../src/config/workspace-overrides.js';
-import type { VGuardConfig } from '../../src/types.js';
+import type { MonorepoConfig, VGuardConfig } from '../../src/types.js';
 
 describe('findWorkspaceOverride', () => {
   it('returns null when monorepo is undefined', () => {
@@ -137,5 +139,73 @@ describe('applyWorkspaceOverride', () => {
     const out = applyWorkspaceOverride(baseConfig, 'apps/mobile/foo.ts');
     expect(out.agents).toEqual(['claude-code']);
     expect(out.monorepo?.packages).toEqual(['apps/*', 'libs/*']);
+  });
+});
+
+describe('buildWorkspaceGlobRegex', () => {
+  it('anchors the regex (no partial-prefix matches)', () => {
+    const re = buildWorkspaceGlobRegex('apps/mobile');
+    expect(re.test('apps/mobile')).toBe(true);
+    expect(re.test('apps/mobile/foo.ts')).toBe(true);
+    expect(re.test('libs/apps/mobile')).toBe(false);
+  });
+
+  it('escapes regex metacharacters in literal segments', () => {
+    const re = buildWorkspaceGlobRegex('apps/my-app.v1');
+    expect(re.test('apps/my-app.v1/foo.ts')).toBe(true);
+    // The dot would match any char if not escaped — this confirms the escape.
+    expect(re.test('apps/myXapp.v1/foo.ts')).toBe(false);
+  });
+
+  it('treats ** as recursive wildcard', () => {
+    const re = buildWorkspaceGlobRegex('apps/**');
+    expect(re.test('apps/mobile/nested/deep.ts')).toBe(true);
+    expect(re.test('libs/mobile')).toBe(false);
+  });
+});
+
+describe('matcher compilation is cached per MonorepoConfig reference', () => {
+  it('reuses compiled matchers across repeat lookups on the same config', () => {
+    const monorepo: MonorepoConfig = {
+      packages: ['apps/*'],
+      overrides: {
+        'apps/mobile': { presets: ['react-native'] },
+        'apps/web': { presets: ['web'] },
+      },
+    };
+
+    const before = __testGetCompileCount();
+
+    findWorkspaceOverride(monorepo, 'apps/mobile/a.ts');
+    const afterFirst = __testGetCompileCount();
+
+    findWorkspaceOverride(monorepo, 'apps/mobile/b.ts');
+    findWorkspaceOverride(monorepo, 'apps/web/c.ts');
+    findWorkspaceOverride(monorepo, 'libs/d.ts');
+    const afterRepeats = __testGetCompileCount();
+
+    // First call compiled once.
+    expect(afterFirst - before).toBe(1);
+    // Repeat calls against the same reference add zero compilations.
+    expect(afterRepeats - afterFirst).toBe(0);
+  });
+
+  it('compiles separately for distinct MonorepoConfig references', () => {
+    const makeConfig = (): MonorepoConfig => ({
+      packages: ['apps/*'],
+      overrides: { 'apps/mobile': { presets: ['react-native'] } },
+    });
+
+    const before = __testGetCompileCount();
+
+    findWorkspaceOverride(makeConfig(), 'apps/mobile/foo.ts');
+    const afterA = __testGetCompileCount();
+
+    findWorkspaceOverride(makeConfig(), 'apps/mobile/foo.ts');
+    const afterB = __testGetCompileCount();
+
+    // Each fresh object got its own compilation pass.
+    expect(afterA - before).toBe(1);
+    expect(afterB - afterA).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to PR #66 flagged in the plan-completion audit. Caches compiled workspace glob matchers per `MonorepoConfig` reference so a lint run over a large monorepo doesn't rebuild the same RegExps on every file lookup.

## What changed

- **`src/config/workspace-overrides.ts`** — new `WeakMap<MonorepoConfig, CompiledOverride[]>` cache. First `findWorkspaceOverride` call against a given config compiles once (RegExp per key + wildcard count + literal prefix length); every subsequent call is a direct table walk. WeakMap means the cache GCs with the config.
- **`buildWorkspaceGlobRegex(pattern)`** is now a named export for direct test coverage.
- **`__testGetCompileCount()`** — test-only observable (not part of the public contract) for asserting cache behaviour without monkey-patching global `RegExp` (which vitest's `vi.spyOn` does poorly for `new`-invocations).

## Base branch

Targets `feat/monorepo-overrides` (**PR #66**). Re-target to `dev` after #66 merges.

## Test plan

- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm test` — 1439 tests pass (+5 new)
- [x] `npx prettier --check .` — clean
- [x] `buildWorkspaceGlobRegex` cases: anchor behaviour, literal dot escaping, `**` recursive wildcard
- [x] Caching: repeat lookups add zero compilations; distinct references compile separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)