### PR TITLE
feat(cloud): keyring-backed credential storage with file fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   excerpts) to an attacker-controlled server. Local development against
   `localhost` / private IP ranges is still available behind an explicit
   `VGUARD_DEV=1`. Fixes #48.
+- **Cloud credentials now prefer the OS keychain over the file.**
+  `writeCredentials()` / `readCredentials()` default to the platform
+  secret store (Windows Credential Manager, macOS Keychain, Linux
+  Secret Service via `@napi-rs/keyring`) with the legacy
+  `~/.vguard/credentials.json` path kept as a fallback for
+  environments where the native binding is absent or no secret
+  daemon is running. A new `VGUARD_CREDENTIAL_STORE` env var
+  (`auto` / `keyring` / `file`, default `auto`) pins the backend
+  explicitly for CI. On first read, a legacy file is transparently
+  migrated into the keyring and the plaintext file is removed, so
+  upgrading is zero-friction. `@napi-rs/keyring` ships as an
+  `optionalDependencies` entry — installs that skip the native
+  binding (exotic platforms, `--no-optional` CI) automatically land
+  on the file fallback. Closes the "next-major" half of #47.
 - **Credentials file is now ACL-locked on Windows.** The `mode: 0o600`
   in `writeCredentials()` was silently ignored on NTFS: Node does not
   map POSIX modes to Windows ACLs, so `~/.vguard/credentials.json`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthril/vguard",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthril/vguard",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.2",
@@ -35,6 +35,9 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring": "^1.2.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1400,6 +1403,226 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/keyring": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.2.0.tgz",
+      "integrity": "sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring-darwin-arm64": "1.2.0",
+        "@napi-rs/keyring-darwin-x64": "1.2.0",
+        "@napi-rs/keyring-freebsd-x64": "1.2.0",
+        "@napi-rs/keyring-linux-arm-gnueabihf": "1.2.0",
+        "@napi-rs/keyring-linux-arm64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-arm64-musl": "1.2.0",
+        "@napi-rs/keyring-linux-riscv64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-x64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-x64-musl": "1.2.0",
+        "@napi-rs/keyring-win32-arm64-msvc": "1.2.0",
+        "@napi-rs/keyring-win32-ia32-msvc": "1.2.0",
+        "@napi-rs/keyring-win32-x64-msvc": "1.2.0"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.2.0.tgz",
+      "integrity": "sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.2.0.tgz",
+      "integrity": "sha512-dBHjtKRCj4ByfnfqIKIJLo3wueQNJhLRyuxtX/rR4K/XtcS7VLlRD01XXizjpre54vpmObj63w+ZpHG+mGM8uA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-freebsd-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.2.0.tgz",
+      "integrity": "sha512-DPZFr11pNJSnaoh0dzSUNF+T6ORhy3CkzUT3uGixbA71cAOPJ24iG8e8QrLOkuC/StWrAku3gBnth2XMWOcR3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.2.0.tgz",
+      "integrity": "sha512-8xv6DyEMlvRdqJzp4F39RLUmmTQsLcGYYv/3eIfZNZN1O5257tHxTrFYqAsny659rJJK2EKeSa7PhrSibQqRWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.2.0.tgz",
+      "integrity": "sha512-Pu2V6Py+PBt7inryEecirl+t+ti8bhZphjP+W68iVaXHUxLdWmkgL9KI1VkbRHbx5k8K5Tew9OP218YfmVguIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.2.0.tgz",
+      "integrity": "sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.2.0.tgz",
+      "integrity": "sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.2.0.tgz",
+      "integrity": "sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.2.0.tgz",
+      "integrity": "sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-arm64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.2.0.tgz",
+      "integrity": "sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-ia32-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.2.0.tgz",
+      "integrity": "sha512-EYL+EEI6bCsYi3LfwcQdnX3P/R76ENKNn+3PmpGheBsUFLuh0gQuP7aMVHM4rTw6UVe+L3vCLZSptq/oeacz0A==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-x64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.2.0.tgz",
+      "integrity": "sha512-xFlx/TsmqmCwNU9v+AVnEJgoEAlBYgzFF5Ihz1rMpPAt4qQWWkMd4sCyM1gMJ1A/GnRqRegDiQpwaxGUHFtFbA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,9 @@
     "jiti": "^2.6.1",
     "zod": "^4.3.6"
   },
+  "optionalDependencies": {
+    "@napi-rs/keyring": "^1.2.0"
+  },
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",

--- a/src/cloud/credentials-types.ts
+++ b/src/cloud/credentials-types.ts
@@ -1,0 +1,31 @@
+/**
+ * Shape of the Cloud credential blob, stored either in
+ * `~/.vguard/credentials.json` (legacy / fallback) or in the OS
+ * keyring under service `vguard`, account `credentials` (preferred,
+ * opt-in via the keyring follow-up).
+ *
+ * Extracted into its own module so `credentials.ts` and
+ * `keyring-storage.ts` can both import the type without creating a
+ * circular dependency between the two storage backends.
+ */
+export interface CloudCredentials {
+  /** Supabase access token (JWT) — set by `cloud login`, absent when user
+   *  connects via `cloud connect --key` with an existing API key. */
+  accessToken?: string;
+  /** Supabase refresh token — used to get new access tokens when expired */
+  refreshToken?: string;
+  /** Token expiry timestamp (ISO 8601) */
+  expiresAt?: string;
+  /** User email */
+  email?: string;
+  /** Cloud API URL (stored so CLI knows where to connect) */
+  apiUrl?: string;
+  /** Supabase project URL (needed for token refresh) */
+  supabaseUrl?: string;
+  /** Supabase anon/publishable key (needed for token refresh) */
+  supabaseAnonKey?: string;
+  /** Project API key (vc_ prefix) for syncing rule hits */
+  apiKey?: string;
+  /** Connected project ID */
+  projectId?: string;
+}

--- a/src/cloud/credentials.ts
+++ b/src/cloud/credentials.ts
@@ -3,36 +3,93 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { sanitiseBaseUrl } from './url-guard.js';
 import { restrictCredentialsAcl } from './acl-guard.js';
+import type { CloudCredentials } from './credentials-types.js';
+import {
+  isKeyringAvailable,
+  readCredentialsFromKeyring,
+  writeCredentialsToKeyring,
+  clearCredentialsFromKeyring,
+} from './keyring-storage.js';
+
+export type { CloudCredentials } from './credentials-types.js';
 
 const CREDENTIALS_DIR = join(homedir(), '.vguard');
 const CREDENTIALS_FILE = join(CREDENTIALS_DIR, 'credentials.json');
 
-export interface CloudCredentials {
-  /** Supabase access token (JWT) — set by `cloud login`, absent when user
-   *  connects via `cloud connect --key` with an existing API key. */
-  accessToken?: string;
-  /** Supabase refresh token — used to get new access tokens when expired */
-  refreshToken?: string;
-  /** Token expiry timestamp (ISO 8601) */
-  expiresAt?: string;
-  /** User email */
-  email?: string;
-  /** Cloud API URL (stored so CLI knows where to connect) */
-  apiUrl?: string;
-  /** Supabase project URL (needed for token refresh) */
-  supabaseUrl?: string;
-  /** Supabase anon/publishable key (needed for token refresh) */
-  supabaseAnonKey?: string;
-  /** Project API key (vc_ prefix) for syncing rule hits */
-  apiKey?: string;
-  /** Connected project ID */
-  projectId?: string;
+/**
+ * Which backend to use for credential storage.
+ *
+ *   - `auto` (default) — prefer the OS keyring when available, fall back
+ *     to the legacy `~/.vguard/credentials.json` file on platforms where
+ *     the native binding failed to install or no secret-service daemon
+ *     is running.
+ *   - `keyring` — force the keyring path. Returns null / no-op when the
+ *     keyring is unavailable, rather than falling back.
+ *   - `file` — force the legacy file path. Skips the keyring entirely.
+ *
+ * Override via `VGUARD_CREDENTIAL_STORE`. Useful in CI (where the
+ * keyring daemon often isn't present and the file path is the right
+ * choice) and during the transition period while users migrate.
+ */
+type CredentialBackend = 'auto' | 'keyring' | 'file';
+
+function configuredBackend(): CredentialBackend {
+  const raw = process.env.VGUARD_CREDENTIAL_STORE?.toLowerCase();
+  if (raw === 'keyring' || raw === 'file' || raw === 'auto') return raw;
+  return 'auto';
+}
+
+/**
+ * Whether the current invocation should attempt to use the keyring.
+ * Purely a read of the env var + liveness check — no I/O beyond the
+ * keyring's own empty-probe in `isKeyringAvailable`.
+ */
+function shouldUseKeyring(): boolean {
+  const backend = configuredBackend();
+  if (backend === 'file') return false;
+  if (backend === 'keyring') return true;
+  return isKeyringAvailable();
 }
 
 /**
  * Read stored Cloud credentials.
+ *
+ * In `auto` mode: tries the keyring first, falls back to the file.
+ * If the keyring is present but empty AND a legacy file exists, the
+ * file is migrated into the keyring transparently (first-read
+ * migration) — after which the plaintext file is deleted.
  */
 export function readCredentials(): CloudCredentials | null {
+  const backend = configuredBackend();
+
+  if (backend !== 'file' && shouldUseKeyring()) {
+    const fromKeyring = readCredentialsFromKeyring();
+    if (fromKeyring) return fromKeyring;
+    // Keyring is available but empty. Check for a legacy file and
+    // migrate it in. This runs at most once per user — after the
+    // migration writes to the keyring, the file is removed.
+    if (backend === 'auto' && existsSync(CREDENTIALS_FILE)) {
+      const fromFile = readCredentialsFile();
+      if (fromFile) {
+        if (writeCredentialsToKeyring(fromFile)) {
+          // Keyring now holds the data. Drop the plaintext file so
+          // reviewers of the home directory don't see stale creds.
+          try {
+            unlinkSync(CREDENTIALS_FILE);
+          } catch {
+            // Non-fatal — the file stays but the keyring is the source of truth.
+          }
+        }
+        return fromFile;
+      }
+    }
+    return null;
+  }
+
+  return readCredentialsFile();
+}
+
+function readCredentialsFile(): CloudCredentials | null {
   try {
     if (!existsSync(CREDENTIALS_FILE)) return null;
     const raw = readFileSync(CREDENTIALS_FILE, 'utf-8');
@@ -43,14 +100,42 @@ export function readCredentials(): CloudCredentials | null {
 }
 
 /**
- * Store Cloud credentials to disk.
+ * Store Cloud credentials.
  *
- * The `mode: 0o600` / `0o700` below locks the file on POSIX but is
- * effectively ignored on Windows — Node does not map numeric POSIX modes
- * to NTFS ACLs, so the credentials end up readable by any local user.
- * `restrictCredentialsAcl` closes that gap on Windows via `icacls`.
+ * In `auto` mode: writes to the keyring when available, falls back to
+ * the legacy file with `mode: 0o600` + `restrictCredentialsAcl` on
+ * Windows. On a successful keyring write, any pre-existing plaintext
+ * credentials file is removed so secrets don't linger on disk.
  */
 export function writeCredentials(credentials: CloudCredentials): void {
+  if (shouldUseKeyring()) {
+    const wrote = writeCredentialsToKeyring(credentials);
+    if (wrote) {
+      // Clean up the legacy file if it still exists. Best-effort.
+      if (existsSync(CREDENTIALS_FILE)) {
+        try {
+          unlinkSync(CREDENTIALS_FILE);
+        } catch {
+          /* legacy file still present — non-fatal */
+        }
+      }
+      return;
+    }
+    if (configuredBackend() === 'keyring') {
+      // Explicitly asked for keyring-only. Refuse to silently write to
+      // disk instead — respect the user's intent.
+      throw new Error(
+        'VGUARD_CREDENTIAL_STORE=keyring but the keyring is unavailable or the write failed. ' +
+          'Either start the platform secret service or set VGUARD_CREDENTIAL_STORE=auto/file.',
+      );
+    }
+    // auto mode: fall through to the file path.
+  }
+
+  writeCredentialsFile(credentials);
+}
+
+function writeCredentialsFile(credentials: CloudCredentials): void {
   if (!existsSync(CREDENTIALS_DIR)) {
     mkdirSync(CREDENTIALS_DIR, { recursive: true, mode: 0o700 });
   }
@@ -62,9 +147,12 @@ export function writeCredentials(credentials: CloudCredentials): void {
 }
 
 /**
- * Remove stored Cloud credentials.
+ * Remove stored Cloud credentials from both backends. `vguard cloud
+ * logout` calls this — users expect it to clear credentials regardless
+ * of which backend was used to store them, so we clean up both.
  */
 export function clearCredentials(): void {
+  clearCredentialsFromKeyring();
   try {
     if (existsSync(CREDENTIALS_FILE)) {
       unlinkSync(CREDENTIALS_FILE);
@@ -162,6 +250,21 @@ export async function getValidCredentials(): Promise<CloudCredentials | null> {
   return creds;
 }
 
+/**
+ * Path where credentials would be written on the file-backend fallback
+ * path. Surfaced for `vguard cloud login` success messages and
+ * `doctor` output. Users on the keyring backend see this path in
+ * documentation; the actual storage is the keychain.
+ */
 export function getCredentialsPath(): string {
   return CREDENTIALS_FILE;
+}
+
+/**
+ * Report which backend `readCredentials` / `writeCredentials` will
+ * currently use. Exposed for `doctor` and CLI status output so users
+ * can see whether their tokens are in the keyring or on disk.
+ */
+export function getActiveCredentialBackend(): 'keyring' | 'file' {
+  return shouldUseKeyring() ? 'keyring' : 'file';
 }

--- a/src/cloud/keyring-storage.ts
+++ b/src/cloud/keyring-storage.ts
@@ -1,0 +1,151 @@
+import type { CloudCredentials } from './credentials-types.js';
+
+/**
+ * OS-keychain-backed credential storage.
+ *
+ * Wraps `@napi-rs/keyring` so VGuard can store Cloud credentials in the
+ * platform's native secret store instead of a plaintext file under
+ * `~/.vguard/credentials.json`:
+ *
+ *   - Windows → Credential Manager
+ *   - macOS   → Keychain
+ *   - Linux   → Secret Service (GNOME Keyring, KWallet, libsecret)
+ *
+ * `@napi-rs/keyring` is an `optionalDependencies` entry. If the native
+ * binding fails to install on the user's platform (uncommon but
+ * possible on niche targets), `isKeyringAvailable()` returns `false`
+ * and callers fall through to the file-based implementation that
+ * shipped in #47/#60. No throw at import time.
+ *
+ * Service / account naming convention:
+ *   - service = `vguard`
+ *   - account = `credentials` (single-entry per user — VGuard only
+ *     ever stores one credential blob per OS user)
+ *
+ * The payload is the same JSON blob `writeCredentials()` used to dump
+ * to disk, so rolling back to file storage is a one-line config flip.
+ */
+
+const KEYRING_SERVICE = 'vguard';
+const KEYRING_ACCOUNT = 'credentials';
+
+interface KeyringEntry {
+  getPassword(): string | null;
+  setPassword(password: string): void;
+  deletePassword(): boolean;
+}
+
+export interface KeyringModule {
+  Entry: new (service: string, account: string) => KeyringEntry;
+}
+
+let cachedModule: KeyringModule | null | false = false;
+
+/**
+ * Test-only override for the module loader. Passing `null` forces
+ * `tryLoadKeyring` to return `null` (simulate native binding absent);
+ * passing an object uses it as the keyring module; calling with no
+ * args clears the override. Not part of the public contract.
+ */
+export function __setKeyringForTesting(mod: KeyringModule | null | undefined): void {
+  if (mod === undefined) {
+    cachedModule = false;
+  } else {
+    cachedModule = mod ?? null;
+  }
+}
+
+/**
+ * Try to load `@napi-rs/keyring`. Returns `null` and caches the
+ * failure on any loader error so we never retry the import per call.
+ *
+ * `false` as the initial sentinel distinguishes "not yet attempted"
+ * from "attempted and failed" (`null`).
+ */
+function tryLoadKeyring(): KeyringModule | null {
+  if (cachedModule !== false) return cachedModule;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('@napi-rs/keyring') as KeyringModule;
+    if (typeof mod.Entry !== 'function') {
+      cachedModule = null;
+      return null;
+    }
+    cachedModule = mod;
+    return mod;
+  } catch {
+    cachedModule = null;
+    return null;
+  }
+}
+
+/**
+ * Whether the keyring backend is usable on this host right now.
+ *
+ * Tests both that the native binding loaded *and* that an `Entry`
+ * roundtrip survives — on headless Linux without a running Secret
+ * Service daemon the module loads but `getPassword` throws. We check
+ * by attempting an empty read.
+ */
+export function isKeyringAvailable(): boolean {
+  const mod = tryLoadKeyring();
+  if (!mod) return false;
+  try {
+    const entry = new mod.Entry(KEYRING_SERVICE, KEYRING_ACCOUNT);
+    // Probing an absent password is the smallest possible roundtrip.
+    entry.getPassword();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read credentials from the keyring. Returns null if the entry is
+ * absent or the keyring is unavailable.
+ */
+export function readCredentialsFromKeyring(): CloudCredentials | null {
+  const mod = tryLoadKeyring();
+  if (!mod) return null;
+  try {
+    const entry = new mod.Entry(KEYRING_SERVICE, KEYRING_ACCOUNT);
+    const raw = entry.getPassword();
+    if (!raw) return null;
+    return JSON.parse(raw) as CloudCredentials;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Store credentials in the keyring. Returns `true` on success; `false`
+ * when the keyring is unavailable or the write failed. Callers must
+ * fall back to file storage on `false`.
+ */
+export function writeCredentialsToKeyring(credentials: CloudCredentials): boolean {
+  const mod = tryLoadKeyring();
+  if (!mod) return false;
+  try {
+    const entry = new mod.Entry(KEYRING_SERVICE, KEYRING_ACCOUNT);
+    entry.setPassword(JSON.stringify(credentials));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Remove credentials from the keyring. Returns `true` when the entry
+ * was present and deleted, `false` otherwise (including when the
+ * keyring is unavailable — treat it as "already gone").
+ */
+export function clearCredentialsFromKeyring(): boolean {
+  const mod = tryLoadKeyring();
+  if (!mod) return false;
+  try {
+    const entry = new mod.Entry(KEYRING_SERVICE, KEYRING_ACCOUNT);
+    return entry.deletePassword();
+  } catch {
+    return false;
+  }
+}

--- a/tests/cloud/credentials-keyring.test.ts
+++ b/tests/cloud/credentials-keyring.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import type { KeyringModule } from '../../src/cloud/keyring-storage.js';
+
+// Redirect $HOME so `credentials.ts` writes to a tmp dir instead of the
+// developer's real `~/.vguard`. `credentials.ts` calls `homedir()` at
+// module init (for the `const CREDENTIALS_DIR`), so the env var must be
+// set before import — we use `vi.resetModules` + dynamic import.
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+const originalBackend = process.env.VGUARD_CREDENTIAL_STORE;
+
+let tmpHome: string;
+
+const fakeStorage = new Map<string, string>();
+
+function makeFakeKeyring(): KeyringModule {
+  class Entry {
+    constructor(
+      public service: string,
+      public account: string,
+    ) {}
+    getPassword(): string | null {
+      return fakeStorage.get(`${this.service}:${this.account}`) ?? null;
+    }
+    setPassword(password: string): void {
+      fakeStorage.set(`${this.service}:${this.account}`, password);
+    }
+    deletePassword(): boolean {
+      return fakeStorage.delete(`${this.service}:${this.account}`);
+    }
+  }
+  return { Entry } as KeyringModule;
+}
+
+async function loadCredentialsModule(
+  backend: 'auto' | 'keyring' | 'file',
+  keyring: KeyringModule | null = makeFakeKeyring(),
+) {
+  vi.resetModules();
+  process.env.VGUARD_CREDENTIAL_STORE = backend;
+  process.env.HOME = tmpHome;
+  process.env.USERPROFILE = tmpHome;
+
+  // Re-import keyring-storage on the freshly reset module graph, then
+  // inject our fake before loading credentials. The `credentials.ts`
+  // module reads the keyring-storage singleton at runtime so the
+  // injection here is what its calls will see.
+  const ks = await import('../../src/cloud/keyring-storage.js');
+  ks.__setKeyringForTesting(keyring);
+  return await import('../../src/cloud/credentials.js');
+}
+
+describe('credentials backend selection', () => {
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'vguard-creds-test-'));
+    fakeStorage.clear();
+  });
+
+  afterEach(async () => {
+    if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
+    // Reset the keyring-storage module's injected state so it doesn't
+    // leak into other test files that happen to import the same module.
+    const ks = await import('../../src/cloud/keyring-storage.js');
+    ks.__setKeyringForTesting(undefined);
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    if (originalBackend === undefined) delete process.env.VGUARD_CREDENTIAL_STORE;
+    else process.env.VGUARD_CREDENTIAL_STORE = originalBackend;
+  });
+
+  it('auto backend writes to keyring when available (no plaintext file)', async () => {
+    const mod = await loadCredentialsModule('auto');
+    mod.writeCredentials({ apiKey: 'vc_from_auto' });
+    expect(fakeStorage.get('vguard:credentials')).toContain('vc_from_auto');
+    expect(existsSync(join(tmpHome, '.vguard', 'credentials.json'))).toBe(false);
+    expect(mod.getActiveCredentialBackend()).toBe('keyring');
+  });
+
+  it('auto backend reads from keyring', async () => {
+    fakeStorage.set('vguard:credentials', JSON.stringify({ apiKey: 'vc_preloaded' }));
+    const mod = await loadCredentialsModule('auto');
+    expect(mod.readCredentials()).toEqual({ apiKey: 'vc_preloaded' });
+  });
+
+  it('auto backend migrates legacy file into keyring on first read', async () => {
+    // Keyring empty; legacy file present.
+    const credDir = join(tmpHome, '.vguard');
+    mkdirSync(credDir, { recursive: true });
+    const credFile = join(credDir, 'credentials.json');
+    writeFileSync(credFile, JSON.stringify({ apiKey: 'vc_legacy' }));
+
+    const mod = await loadCredentialsModule('auto');
+    const out = mod.readCredentials();
+    expect(out).toEqual({ apiKey: 'vc_legacy' });
+    // Migration: now in keyring, file removed.
+    expect(fakeStorage.get('vguard:credentials')).toContain('vc_legacy');
+    expect(existsSync(credFile)).toBe(false);
+  });
+
+  it('file backend ignores the keyring entirely', async () => {
+    fakeStorage.set('vguard:credentials', JSON.stringify({ apiKey: 'vc_keyring_only' }));
+    const mod = await loadCredentialsModule('file');
+    expect(mod.readCredentials()).toBeNull();
+    expect(mod.getActiveCredentialBackend()).toBe('file');
+  });
+
+  it('file backend writes to disk with no keyring touch', async () => {
+    const mod = await loadCredentialsModule('file');
+    mod.writeCredentials({ apiKey: 'vc_file_only' });
+    expect(existsSync(join(tmpHome, '.vguard', 'credentials.json'))).toBe(true);
+    expect(fakeStorage.size).toBe(0);
+  });
+
+  it('keyring backend throws when keyring unavailable', async () => {
+    const mod = await loadCredentialsModule('keyring', null);
+    expect(() => mod.writeCredentials({ apiKey: 'x' })).toThrow(/keyring/i);
+  });
+
+  it('clearCredentials wipes both backends', async () => {
+    fakeStorage.set('vguard:credentials', JSON.stringify({ apiKey: 'vc_in_keyring' }));
+    const credDir = join(tmpHome, '.vguard');
+    mkdirSync(credDir, { recursive: true });
+    writeFileSync(join(credDir, 'credentials.json'), JSON.stringify({ apiKey: 'vc_on_disk' }));
+
+    const mod = await loadCredentialsModule('auto');
+    mod.clearCredentials();
+
+    expect(fakeStorage.size).toBe(0);
+    expect(existsSync(join(credDir, 'credentials.json'))).toBe(false);
+  });
+});

--- a/tests/cloud/keyring-storage.test.ts
+++ b/tests/cloud/keyring-storage.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  __setKeyringForTesting,
+  clearCredentialsFromKeyring,
+  isKeyringAvailable,
+  readCredentialsFromKeyring,
+  writeCredentialsToKeyring,
+  type KeyringModule,
+} from '../../src/cloud/keyring-storage.js';
+
+const storage = new Map<string, string>();
+
+function makeFakeKeyring(
+  options: { getThrows?: boolean; setThrows?: boolean } = {},
+): KeyringModule {
+  class Entry {
+    constructor(
+      public service: string,
+      public account: string,
+    ) {}
+    getPassword(): string | null {
+      if (options.getThrows) throw new Error('keyring daemon unreachable');
+      return storage.get(`${this.service}:${this.account}`) ?? null;
+    }
+    setPassword(password: string): void {
+      if (options.setThrows) throw new Error('write failed');
+      storage.set(`${this.service}:${this.account}`, password);
+    }
+    deletePassword(): boolean {
+      return storage.delete(`${this.service}:${this.account}`);
+    }
+  }
+  return { Entry } as KeyringModule;
+}
+
+describe('keyring-storage', () => {
+  beforeEach(() => {
+    storage.clear();
+  });
+
+  afterEach(() => {
+    __setKeyringForTesting(undefined);
+  });
+
+  it('isKeyringAvailable returns false when the native binding is absent', () => {
+    __setKeyringForTesting(null);
+    expect(isKeyringAvailable()).toBe(false);
+  });
+
+  it('isKeyringAvailable returns true when a healthy Entry roundtrips', () => {
+    __setKeyringForTesting(makeFakeKeyring());
+    expect(isKeyringAvailable()).toBe(true);
+  });
+
+  it('isKeyringAvailable returns false when getPassword throws (no daemon)', () => {
+    __setKeyringForTesting(makeFakeKeyring({ getThrows: true }));
+    expect(isKeyringAvailable()).toBe(false);
+  });
+
+  it('read / write / delete roundtrip', () => {
+    __setKeyringForTesting(makeFakeKeyring());
+    expect(readCredentialsFromKeyring()).toBeNull();
+    expect(writeCredentialsToKeyring({ apiKey: 'vc_abc123' })).toBe(true);
+    expect(readCredentialsFromKeyring()).toEqual({ apiKey: 'vc_abc123' });
+    expect(clearCredentialsFromKeyring()).toBe(true);
+    expect(readCredentialsFromKeyring()).toBeNull();
+  });
+
+  it('write returns false when the native binding is unavailable', () => {
+    __setKeyringForTesting(null);
+    expect(writeCredentialsToKeyring({ apiKey: 'x' })).toBe(false);
+  });
+
+  it('write returns false when setPassword throws', () => {
+    __setKeyringForTesting(makeFakeKeyring({ setThrows: true }));
+    expect(writeCredentialsToKeyring({ apiKey: 'x' })).toBe(false);
+  });
+
+  it('read returns null on malformed stored JSON', () => {
+    __setKeyringForTesting(makeFakeKeyring());
+    // Bypass the public API to inject invalid JSON into the shared map.
+    storage.set('vguard:credentials', 'not json');
+    expect(readCredentialsFromKeyring()).toBeNull();
+  });
+
+  it('clear returns false when the native binding is unavailable', () => {
+    __setKeyringForTesting(null);
+    expect(clearCredentialsFromKeyring()).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,13 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
+    // Force file-backend credential storage in tests so they are
+    // deterministic regardless of whether the developer's OS keyring
+    // has real vguard credentials. Individual keyring-specific tests
+    // opt into the keyring by overriding this locally.
+    env: {
+      VGUARD_CREDENTIAL_STORE: 'file',
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov', 'json-summary'],


### PR DESCRIPTION
## Summary

Closes the "next-major-sized" half of #47 that PR #60 explicitly deferred. Moves Cloud credentials from a plaintext file at `~/.vguard/credentials.json` to the platform-native secret store, with the file path kept as a transparent fallback.

## What changed

**New module `src/cloud/keyring-storage.ts`** wraps `@napi-rs/keyring`:

- Windows → Credential Manager
- macOS   → Keychain
- Linux   → Secret Service (GNOME Keyring / KWallet / libsecret)

`@napi-rs/keyring` declared as `optionalDependencies` — `npm install` on platforms without a prebuild won't fail; the loader catches the import failure and the file-backed path kicks in.

**`src/cloud/credentials.ts`** now routes through a backend selector controlled by `VGUARD_CREDENTIAL_STORE=auto|keyring|file` (default `auto`):

- `auto` — keyring when available, file otherwise. First read migrates any legacy file into the keyring and deletes the file. **Zero-friction upgrade**.
- `keyring` — keyring only; write throws when unavailable (no silent disk writes).
- `file` — file only (used by CI and test determinism).

**`credentials-types.ts`** extracted to break the circular import between the two storage backends.

**`getActiveCredentialBackend()`** exported for `doctor` / CLI status output.

## Base branch

Targets `fix/windows-creds-acl` (**PR #60**) — re-target to `dev` after #60 merges. `TRUST_MODEL.md` updates will land in a separate follow-up once PR #68 (`docs/trust-model`) merges and I can edit the file that's on that branch.

## Test plan

- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm test` — 1441 tests pass (+15 new)
- [x] `npx prettier --check .` — clean
- [x] `tests/cloud/keyring-storage.test.ts` — 8 cases: binding absent, daemon throws, round-trip, write-refusal paths, malformed-JSON recovery
- [x] `tests/cloud/credentials-keyring.test.ts` — 7 cases: auto-backend write/read, legacy-file migration, file-backend isolation, file-backend write, keyring-only throw, `clearCredentials` wipes both backends
- [x] `vitest.config.ts` now defaults to `VGUARD_CREDENTIAL_STORE=file` for determinism; keyring tests override locally
- [ ] Manual on a machine with a working keyring: run `npx vguard cloud login`, verify `icacls` / `keyctl` / `security find-generic-password` shows the token in the keyring and no `~/.vguard/credentials.json` file exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)